### PR TITLE
upgrade golangci-lint to v1.52.2

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:
-          version: v1.50.1
+          version: v1.52.2
           args: --timeout 300s --skip-dirs test/skoop/e2e --skip-dirs-use-default -v -E goconst -E gofmt -E ineffassign -E goimports -E revive -E misspell -E vet -E deadcode
 
   shellcheck:

--- a/pkg/exporter/bpfutil/format.go
+++ b/pkg/exporter/bpfutil/format.go
@@ -85,7 +85,7 @@ func GetCommString(comm [20]int8) string {
 	return strings.TrimSpace(string(buf))
 }
 
-func GetTCPState(no uint8) string {
+func GetTCPState(_ uint8) string {
 
 	return "UNKNOW"
 }

--- a/pkg/exporter/cmd/eventserver.go
+++ b/pkg/exporter/cmd/eventserver.go
@@ -73,7 +73,7 @@ func NewEServer(ctx context.Context, config EventConfig) *EServer {
 	return es
 }
 
-func (e *EServer) WatchEvent(req *proto.WatchRequest, srv proto.Inspector_WatchEventServer) error {
+func (e *EServer) WatchEvent(_ *proto.WatchRequest, srv proto.Inspector_WatchEventServer) error {
 	client := getPeerClient(srv.Context())
 	datach := make(chan proto.RawEvent)
 	slog.Ctx(e.ctx).Info("watch event income", "client", client)
@@ -99,7 +99,7 @@ func (e *EServer) WatchEvent(req *proto.WatchRequest, srv proto.Inspector_WatchE
 	return nil
 }
 
-func (e *EServer) QueryMetric(ctx context.Context, req *proto.QueryMetricRequest) (*proto.QueryMetricResponse, error) {
+func (e *EServer) QueryMetric(_ context.Context, _ *proto.QueryMetricRequest) (*proto.QueryMetricResponse, error) {
 	res := &proto.QueryMetricResponse{}
 	return res, nil
 }

--- a/pkg/exporter/nettop/cri.go
+++ b/pkg/exporter/nettop/cri.go
@@ -2,7 +2,7 @@ package nettop
 
 import (
 	"context"
-	fmt "fmt"
+	"fmt"
 	"net"
 	"net/url"
 	"os"
@@ -168,93 +168,93 @@ func NewRemoteRuntimeService(endpoint string, connectionTimeout time.Duration) (
 }
 
 // Attach prepares a streaming endpoint to attach to a running container, and returns the address.
-func (r *remoteRuntimeService) Attach(req *runtimeapi.AttachRequest) (*runtimeapi.AttachResponse, error) {
+func (r *remoteRuntimeService) Attach(_ *runtimeapi.AttachRequest) (*runtimeapi.AttachResponse, error) {
 	return nil, nil
 }
 
 // CheckpointContainer triggers a checkpoint of the given CheckpointContainerRequest
-func (r *remoteRuntimeService) CheckpointContainer(options *runtimeapi.CheckpointContainerRequest) error {
+func (r *remoteRuntimeService) CheckpointContainer(_ *runtimeapi.CheckpointContainerRequest) error {
 	return nil
 }
 
 // ContainerStats returns the stats of the container.
-func (r *remoteRuntimeService) ContainerStats(containerID string) (*runtimeapi.ContainerStats, error) {
+func (r *remoteRuntimeService) ContainerStats(_ string) (*runtimeapi.ContainerStats, error) {
 	return nil, nil
 }
 
 // CreateContainer creates a new container in the specified PodSandbox.
-func (r *remoteRuntimeService) CreateContainer(podSandBoxID string, config *runtimeapi.ContainerConfig, sandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
+func (r *remoteRuntimeService) CreateContainer(_ string, _ *runtimeapi.ContainerConfig, _ *runtimeapi.PodSandboxConfig) (string, error) {
 	return "", nil
 }
 
 // Exec prepares a streaming endpoint to execute a command in the container, and returns the address.
-func (r *remoteRuntimeService) Exec(req *runtimeapi.ExecRequest) (*runtimeapi.ExecResponse, error) {
+func (r *remoteRuntimeService) Exec(_ *runtimeapi.ExecRequest) (*runtimeapi.ExecResponse, error) {
 	return nil, nil
 }
 
 // ExecSync executes a command in the container, and returns the stdout output.
 // If command exits with a non-zero exit code, an error is returned.
-func (r *remoteRuntimeService) ExecSync(containerID string, cmd []string, timeout time.Duration) (stdout []byte, stderr []byte, err error) {
+func (r *remoteRuntimeService) ExecSync(_ string, _ []string, _ time.Duration) (stdout []byte, stderr []byte, err error) {
 	return nil, nil, nil
 }
 
-func (r *remoteRuntimeService) GetContainerEvents(containerEventsCh chan *runtimeapi.ContainerEventResponse) error {
+func (r *remoteRuntimeService) GetContainerEvents(_ chan *runtimeapi.ContainerEventResponse) error {
 	return nil
 }
 
 // PortForward prepares a streaming endpoint to forward ports from a PodSandbox, and returns the address.
-func (r *remoteRuntimeService) PortForward(req *runtimeapi.PortForwardRequest) (*runtimeapi.PortForwardResponse, error) {
+func (r *remoteRuntimeService) PortForward(_ *runtimeapi.PortForwardRequest) (*runtimeapi.PortForwardResponse, error) {
 	return nil, nil
 }
 
 // RemoveContainer removes the container. If the container is running, the container
 // should be forced to removal.
-func (r *remoteRuntimeService) RemoveContainer(containerID string) (err error) {
+func (r *remoteRuntimeService) RemoveContainer(_ string) (err error) {
 	return nil
 }
 
 // RemovePodSandbox removes the sandbox. If there are any containers in the
 // sandbox, they should be forcibly removed.
-func (r *remoteRuntimeService) RemovePodSandbox(podSandBoxID string) (err error) {
+func (r *remoteRuntimeService) RemovePodSandbox(_ string) (err error) {
 	return nil
 }
 
 // ReopenContainerLog reopens the container log file.
-func (r *remoteRuntimeService) ReopenContainerLog(containerID string) (err error) {
+func (r *remoteRuntimeService) ReopenContainerLog(_ string) (err error) {
 	return nil
 }
 
 // RunPodSandbox creates and starts a pod-level sandbox. Runtimes should ensure
 // the sandbox is in ready state.
-func (r *remoteRuntimeService) RunPodSandbox(config *runtimeapi.PodSandboxConfig, runtimeHandler string) (string, error) {
+func (r *remoteRuntimeService) RunPodSandbox(_ *runtimeapi.PodSandboxConfig, _ string) (string, error) {
 	return "", nil
 }
 
 // StartContainer starts the container.
-func (r *remoteRuntimeService) StartContainer(containerID string) (err error) {
+func (r *remoteRuntimeService) StartContainer(_ string) (err error) {
 	return nil
 }
 
 // StopContainer stops a running container with a grace period (i.e., timeout).
-func (r *remoteRuntimeService) StopContainer(containerID string, timeout int64) (err error) {
+func (r *remoteRuntimeService) StopContainer(_ string, _ int64) (err error) {
 	return nil
 }
 
 // StopPodSandbox stops the sandbox. If there are any running containers in the
 // sandbox, they should be forced to termination.
-func (r *remoteRuntimeService) StopPodSandbox(podSandBoxID string) (err error) {
+func (r *remoteRuntimeService) StopPodSandbox(_ string) (err error) {
 	return nil
 }
 
 // UpdateContainerResources updates a containers resource config
-func (r *remoteRuntimeService) UpdateContainerResources(containerID string, resources *runtimeapi.ContainerResources) (err error) {
+func (r *remoteRuntimeService) UpdateContainerResources(_ string, _ *runtimeapi.ContainerResources) (err error) {
 	return nil
 }
 
 // UpdateRuntimeConfig updates the config of a runtime service. The only
 // update payload currently supported is the pod CIDR assigned to a node,
 // and the runtime service just proxies it down to the network plugin.
-func (r *remoteRuntimeService) UpdateRuntimeConfig(runtimeConfig *runtimeapi.RuntimeConfig) (err error) {
+func (r *remoteRuntimeService) UpdateRuntimeConfig(_ *runtimeapi.RuntimeConfig) (err error) {
 	return nil
 }
 

--- a/pkg/exporter/nettop/netns_test.go
+++ b/pkg/exporter/nettop/netns_test.go
@@ -4,5 +4,5 @@ import (
 	"testing"
 )
 
-func TestFindNsInum(t *testing.T) {
+func TestFindNsInum(_ *testing.T) {
 }

--- a/pkg/exporter/probe/metric.go
+++ b/pkg/exporter/probe/metric.go
@@ -44,7 +44,7 @@ func init() {
 	availmprobes["virtcmdlatency"] = tracevirtcmdlat.GetProbe()
 }
 
-func ListMetricProbes(ctx context.Context, avail bool) (probelist []string) {
+func ListMetricProbes(_ context.Context, _ bool) (probelist []string) {
 	for k := range availmprobes {
 		probelist = append(probelist, k)
 	}

--- a/pkg/exporter/probe/procio/procio.go
+++ b/pkg/exporter/probe/procio/procio.go
@@ -66,7 +66,7 @@ func (s *ProcIO) Collect(ctx context.Context) (map[string]map[uint32]uint64, err
 	return collect(ctx, ets)
 }
 
-func collect(ctx context.Context, nslist []*nettop.Entity) (map[string]map[uint32]uint64, error) {
+func collect(_ context.Context, _ []*nettop.Entity) (map[string]map[uint32]uint64, error) {
 	resMap := make(map[string]map[uint32]uint64)
 	for _, stat := range IOMetrics {
 		resMap[metricUniqueID("io", stat)] = map[uint32]uint64{}

--- a/pkg/exporter/probe/procnetdev/procnetdev.go
+++ b/pkg/exporter/probe/procnetdev/procnetdev.go
@@ -82,7 +82,7 @@ func metricUniqueID(subject string, m string) string {
 	return fmt.Sprintf("%s%s", subject, strings.ToLower(m))
 }
 
-func collect(ctx context.Context, nslist []*nettop.Entity) (map[string]map[uint32]uint64, error) {
+func collect(_ context.Context, nslist []*nettop.Entity) (map[string]map[uint32]uint64, error) {
 	resMap := make(map[string]map[uint32]uint64)
 	for _, mname := range NetdevMetrics {
 		resMap[metricUniqueID("netdev", mname)] = map[uint32]uint64{}

--- a/pkg/exporter/probe/procnetstat/procnetstat.go
+++ b/pkg/exporter/probe/procnetstat/procnetstat.go
@@ -155,12 +155,12 @@ func collect(ctx context.Context, nslist []*nettop.Entity) (map[string]map[uint3
 		extstats := stats[ProtocolTCPExt]
 		for _, stat := range TCPExtMetrics {
 			if _, ok := extstats[stat]; ok {
-				if data, err := strconv.ParseUint(extstats[stat], 10, 64); err != nil {
+				data, err := strconv.ParseUint(extstats[stat], 10, 64)
+				if err != nil {
 					slog.Ctx(ctx).Warn("collect", "mod", MODULE_NAME, "ignore", stat, "err", err)
 					continue
-				} else {
-					resMap[metricUniqueID("tcpext", stat)][uint32(et.GetNetns())] += data
 				}
+				resMap[metricUniqueID("tcpext", stat)][uint32(et.GetNetns())] += data
 			}
 		}
 	}

--- a/pkg/exporter/probe/procsnmp/procsnmp.go
+++ b/pkg/exporter/probe/procsnmp/procsnmp.go
@@ -152,14 +152,14 @@ func collect(ctx context.Context, entitys []*nettop.Entity) (map[string]map[uint
 				for k, v := range stat {
 					mkey := metricUniqueID(proto, k)
 					slog.Ctx(ctx).Debug("store metric", "metric", mkey, "pid", pid, "nsinum", nsinum, "value", v)
-					if data, err := strconv.ParseInt(v, 10, 64); err != nil {
+					data, err := strconv.ParseInt(v, 10, 64)
+					if err != nil {
 						slog.Ctx(ctx).Debug("parse netstat value", "metric", mkey, "pid", pid, "nsinum", nsinum, "value", v, "err", err)
 						continue
-					} else {
-						// ignore unaware metric
-						if _, ok := res[mkey]; ok {
-							res[mkey][uint32(nsinum)] = uint64(data)
-						}
+					}
+					// ignore unaware metric
+					if _, ok := res[mkey]; ok {
+						res[mkey][uint32(nsinum)] = uint64(data)
 					}
 				}
 			}

--- a/pkg/exporter/probe/procsock/procsock.go
+++ b/pkg/exporter/probe/procsock/procsock.go
@@ -86,7 +86,7 @@ type tcpsockstat struct {
 	Mem    int
 }
 
-func collect(ctx context.Context, nslist []*nettop.Entity) (resMap map[string]map[uint32]uint64, err error) {
+func collect(_ context.Context, nslist []*nettop.Entity) (resMap map[string]map[uint32]uint64, err error) {
 	resMap = make(map[string]map[uint32]uint64)
 	for _, stat := range TCPSockStatMetrics {
 		resMap[metricUniqueID("sock", stat)] = map[uint32]uint64{}

--- a/pkg/exporter/probe/procsoftnet/procsoftnet.go
+++ b/pkg/exporter/probe/procsoftnet/procsoftnet.go
@@ -77,7 +77,7 @@ func metricUniqueID(subject string, m string) string {
 	return fmt.Sprintf("%s%s", subject, strings.ToLower(m))
 }
 
-func collect(ctx context.Context, nslist []*nettop.Entity) (map[string]map[uint32]uint64, error) {
+func collect(_ context.Context, nslist []*nettop.Entity) (map[string]map[uint32]uint64, error) {
 	resMap := make(map[string]map[uint32]uint64)
 
 	for idx := range SoftnetMetrics {

--- a/pkg/exporter/probe/tracekernel/tracekernel.go
+++ b/pkg/exporter/probe/tracekernel/tracekernel.go
@@ -107,7 +107,7 @@ func (p *KernelLatencyProbe) GetMetricNames() []string {
 	return metrics
 }
 
-func (p *KernelLatencyProbe) Collect(ctx context.Context) (map[string]map[uint32]uint64, error) {
+func (p *KernelLatencyProbe) Collect(_ context.Context) (map[string]map[uint32]uint64, error) {
 	return metricsMap, nil
 }
 

--- a/pkg/exporter/probe/tracenetiftxlatency/tracenetiftxlatency.go
+++ b/pkg/exporter/probe/tracenetiftxlatency/tracenetiftxlatency.go
@@ -175,7 +175,7 @@ func (p *NetifTxlatencyProbe) GetMetricNames() []string {
 	return metrics
 }
 
-func (p *NetifTxlatencyProbe) Collect(ctx context.Context) (map[string]map[uint32]uint64, error) {
+func (p *NetifTxlatencyProbe) Collect(_ context.Context) (map[string]map[uint32]uint64, error) {
 	ets := nettop.GetAllEntity()
 	resMap := map[string]map[uint32]uint64{}
 

--- a/pkg/exporter/probe/tracenetsoftirq/tracenetsoftirq.go
+++ b/pkg/exporter/probe/tracenetsoftirq/tracenetsoftirq.go
@@ -74,7 +74,7 @@ func (p *NetSoftirqProbe) GetMetricNames() []string {
 	return metrics
 }
 
-func (p *NetSoftirqProbe) Collect(ctx context.Context) (map[string]map[uint32]uint64, error) {
+func (p *NetSoftirqProbe) Collect(_ context.Context) (map[string]map[uint32]uint64, error) {
 
 	return metricsMap, nil
 }

--- a/pkg/exporter/probe/tracesocketlatency/socketlatency.go
+++ b/pkg/exporter/probe/tracesocketlatency/socketlatency.go
@@ -130,7 +130,7 @@ func (p *SocketLatencyProbe) Start(ctx context.Context) {
 	p.startEventPoll(ctx)
 }
 
-func (p *SocketLatencyProbe) Collect(ctx context.Context) (map[string]map[uint32]uint64, error) {
+func (p *SocketLatencyProbe) Collect(_ context.Context) (map[string]map[uint32]uint64, error) {
 	res := map[string]map[uint32]uint64{}
 	for _, mtr := range socketlatencyMetrics {
 		res[mtr] = map[uint32]uint64{}

--- a/pkg/exporter/probe/tracevirtcmdlat/tracevirtcmdlat.go
+++ b/pkg/exporter/probe/tracevirtcmdlat/tracevirtcmdlat.go
@@ -88,7 +88,7 @@ func (p *VirtcmdLatencyProbe) Close() error {
 	return nil
 }
 
-func (p *VirtcmdLatencyProbe) Collect(ctx context.Context) (map[string]map[uint32]uint64, error) {
+func (p *VirtcmdLatencyProbe) Collect(_ context.Context) (map[string]map[uint32]uint64, error) {
 	return metricsMap, nil
 }
 

--- a/pkg/skoop/assertions/netstack.go
+++ b/pkg/skoop/assertions/netstack.go
@@ -387,7 +387,7 @@ func (na *NetstackAssertion) AssertDefaultAccept() {
 	}
 }
 
-func (na *NetstackAssertion) checkNetfilterResult(verdict netstack.Verdict, err error) bool {
+func (na *NetstackAssertion) checkNetfilterResult(_ netstack.Verdict, err error) bool {
 	if err != nil {
 		if err == netstack.ErrIPTablesUnsupported {
 			na.AddSuspicion(model.SuspicionLevelWarning,

--- a/pkg/skoop/cmd/app.go
+++ b/pkg/skoop/cmd/app.go
@@ -27,10 +27,7 @@ func NewSkoopCmd() *cobra.Command {
 			if err := context.SkoopContext.BuildCluster(); err != nil {
 				return err
 			}
-			if err := context.SkoopContext.BuildTask(); err != nil {
-				return err
-			}
-			return nil
+			return context.SkoopContext.BuildTask()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			prvd, err := provider.GetProvider(context.SkoopContext.ClusterConfig().CloudProvider)

--- a/pkg/skoop/model/netnode.go
+++ b/pkg/skoop/model/netnode.go
@@ -83,7 +83,7 @@ type GenericNetNode struct {
 	NetNode *NetNode
 }
 
-func (n *GenericNetNode) Send(dst Endpoint, protocol Protocol) ([]Transmission, error) {
+func (n *GenericNetNode) Send(_ Endpoint, _ Protocol) ([]Transmission, error) {
 	return nil, fmt.Errorf("non pod/node address as source is not supported")
 }
 

--- a/pkg/skoop/netstack/iptables.go
+++ b/pkg/skoop/netstack/iptables.go
@@ -75,32 +75,32 @@ type SNATTarget struct {
 	Persistent  bool   `ipt:"--persistent"`
 }
 
-func (s *SNATTarget) Do(ctx context.Context, packet *model.Packet, iif, oif string) (XTablesVerdict, error) {
+func (s *SNATTarget) Do(_ context.Context, _ *model.Packet, _, _ string) (XTablesVerdict, error) {
 	return XTablesVerdictAccept, nil
 }
 
-func (t *DNATTarget) Do(ctx context.Context, packet *model.Packet, iif, oif string) (XTablesVerdict, error) {
+func (t *DNATTarget) Do(_ context.Context, _ *model.Packet, _, _ string) (XTablesVerdict, error) {
 	return XTablesVerdictAccept, nil
 }
 
 type MarkTarget struct {
 }
 
-func (t *MarkTarget) Do(ctx context.Context, packet *model.Packet, iif, oif string) (XTablesVerdict, error) {
+func (t *MarkTarget) Do(_ context.Context, _ *model.Packet, _, _ string) (XTablesVerdict, error) {
 	return XTablesVerdictAccept, nil
 }
 
 type NoTrackTarget struct {
 }
 
-func (t *NoTrackTarget) Do(ctx context.Context, packet *model.Packet, iif, oif string) (XTablesVerdict, error) {
+func (t *NoTrackTarget) Do(_ context.Context, _ *model.Packet, _, _ string) (XTablesVerdict, error) {
 	return XTablesVerdictAccept, nil
 }
 
 type TPProxyTarget struct {
 }
 
-func (t *TPProxyTarget) Do(ctx context.Context, packet *model.Packet, iif, oif string) (XTablesVerdict, error) {
+func (t *TPProxyTarget) Do(_ context.Context, _ *model.Packet, _, _ string) (XTablesVerdict, error) {
 	return XTablesVerdictAccept, nil
 }
 
@@ -113,7 +113,7 @@ type TCP struct {
 	Value  uint16
 }
 
-func (t *TCP) Match(ctx context.Context, packet *model.Packet, iif, oif string) (bool, error) {
+func (t *TCP) Match(_ context.Context, packet *model.Packet, _, _ string) (bool, error) {
 	if packet.Protocol != model.TCP {
 		return false, nil
 	}
@@ -136,7 +136,7 @@ type IP struct {
 	Value  string
 }
 
-func (ip *IP) Match(ctx context.Context, packet *model.Packet, iif, oif string) (bool, error) {
+func (ip *IP) Match(_ context.Context, packet *model.Packet, iif, oif string) (bool, error) {
 	switch ip.Option {
 	case "i":
 		return ip.Value == iif, nil
@@ -162,7 +162,7 @@ type UDP struct {
 	Value  uint16
 }
 
-func (udp *UDP) Match(ctx context.Context, packet *model.Packet, iif, oif string) (bool, error) {
+func (udp *UDP) Match(_ context.Context, packet *model.Packet, _, _ string) (bool, error) {
 	if packet.Protocol != model.UDP {
 		return false, nil
 	}
@@ -186,7 +186,7 @@ type Conntrack struct {
 	Value  string
 }
 
-func (conntrack *Conntrack) Match(ctx context.Context, packet *model.Packet, iif, oif string) (bool, error) {
+func (conntrack *Conntrack) Match(_ context.Context, _ *model.Packet, _, _ string) (bool, error) {
 	return true, nil
 }
 func (conntrack *Conntrack) String() string {
@@ -207,7 +207,7 @@ func (set *Set) parseSetArgument() (string, string, error) {
 	return arr[0], arr[1], nil
 }
 
-func (set *Set) Match(ctx context.Context, packet *model.Packet, iif, oif string) (bool, error) {
+func (set *Set) Match(ctx context.Context, packet *model.Packet, _, _ string) (bool, error) {
 	setName, flags, err := set.parseSetArgument()
 	if err != nil {
 		return false, err
@@ -284,7 +284,7 @@ type Comment struct {
 	Value  string
 }
 
-func (c *Comment) Match(ctx context.Context, packet *model.Packet, iif, oif string) (bool, error) {
+func (c *Comment) Match(_ context.Context, _ *model.Packet, _, _ string) (bool, error) {
 	return true, nil
 }
 
@@ -317,7 +317,7 @@ func (mp *MultiPort) matchPort(port uint16) (bool, error) {
 	return false, nil
 }
 
-func (mp *MultiPort) Match(ctx context.Context, packet *model.Packet, iif, oif string) (bool, error) {
+func (mp *MultiPort) Match(_ context.Context, packet *model.Packet, _, _ string) (bool, error) {
 	switch mp.Option {
 	case "dports":
 		return mp.matchPort(packet.Dport)
@@ -361,7 +361,7 @@ type Mark struct {
 	Value  string
 }
 
-func (m *Mark) Match(ctx context.Context, packet *model.Packet, iif, oif string) (bool, error) {
+func (m *Mark) Match(_ context.Context, packet *model.Packet, _, _ string) (bool, error) {
 	mark, mask := parseMarkValue(m.Value)
 	return mark == packet.Mark&mask, nil
 }
@@ -458,7 +458,7 @@ type Statistic struct {
 	Value  string
 }
 
-func (s *Statistic) Match(ctx context.Context, packet *model.Packet, iif, oif string) (bool, error) {
+func (s *Statistic) Match(_ context.Context, _ *model.Packet, _, _ string) (bool, error) {
 	return true, nil
 }
 
@@ -471,7 +471,7 @@ type Physdev struct {
 	Value  string
 }
 
-func (physdev *Physdev) Match(ctx context.Context, packet *model.Packet, iif, oif string) (bool, error) {
+func (physdev *Physdev) Match(_ context.Context, _ *model.Packet, _, _ string) (bool, error) {
 	//FIXME 这里有问题
 	return true, nil
 }
@@ -485,7 +485,7 @@ type Socket struct {
 	Value  string
 }
 
-func (s *Socket) Socket(ctx context.Context, packet *model.Packet, iif, oif string) (bool, error) {
+func (s *Socket) Socket(_ context.Context, _ *model.Packet, _, _ string) (bool, error) {
 	//FIXME 这里有问题
 	return true, nil
 }
@@ -699,7 +699,7 @@ type emptyIPTables struct {
 	xTables map[string]*xTable
 }
 
-func (ipt *emptyIPTables) TracePacket(ctx context.Context, hook NFHook, table string, packet *model.Packet, iif, oif string) (Verdict, Trace, error) {
+func (ipt *emptyIPTables) TracePacket(_ context.Context, _ NFHook, _ string, _ *model.Packet, _, _ string) (Verdict, Trace, error) {
 	return VerdictAccept, nil, nil
 }
 

--- a/pkg/skoop/netstack/iptables_test.go
+++ b/pkg/skoop/netstack/iptables_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestParseIPTables(t *testing.T) {
+func TestParseIPTables(_ *testing.T) {
 	ipt := ParseIPTables(iptablesDump)
 	fmt.Println(ipt)
 }

--- a/pkg/skoop/network/aliyun/infrashim.go
+++ b/pkg/skoop/network/aliyun/infrashim.go
@@ -30,7 +30,7 @@ func NewInfraShim(cloudManager *aliyun.CloudManager) (network.InfraShim, error) 
 	}, nil
 }
 
-func (s *aliyunInfraShim) NodeToNode(src *v1.Node, oif string, dst *v1.Node, packet *model.Packet) ([]model.Suspicion, error) {
+func (s *aliyunInfraShim) NodeToNode(src *v1.Node, _ string, dst *v1.Node, packet *model.Packet) ([]model.Suspicion, error) {
 	klog.V(3).Infof("Node to node packet %+v", packet)
 	srcID, err := s.getECSFromNode(src)
 	if err != nil {
@@ -60,7 +60,7 @@ func (s *aliyunInfraShim) NodeToNode(src *v1.Node, oif string, dst *v1.Node, pac
 	return suspicions, nil
 }
 
-func (s *aliyunInfraShim) NodeToExternal(src *v1.Node, oif string, packet *model.Packet) ([]model.Suspicion, error) {
+func (s *aliyunInfraShim) NodeToExternal(src *v1.Node, _ string, packet *model.Packet) ([]model.Suspicion, error) {
 	srcID, err := s.getECSFromNode(src)
 	if err != nil {
 		return nil, err

--- a/pkg/skoop/network/aliyun/network.go
+++ b/pkg/skoop/network/aliyun/network.go
@@ -195,7 +195,7 @@ func (n *calicoNetwork) Diagnose(ctx *ctx.Context, src model.Endpoint, dst model
 	return n.diagnostor.Diagnose(src, dst, model.Protocol(ctx.TaskConfig().Protocol))
 }
 
-func (n *terwayNetwork) Diagnose(ctx *ctx.Context, src model.Endpoint, dst model.Endpoint) ([]model.Suspicion, *model.PacketPath, error) {
+func (n *terwayNetwork) Diagnose(_ *ctx.Context, _ model.Endpoint, _ model.Endpoint) ([]model.Suspicion, *model.PacketPath, error) {
 	// todo: implement me
 	panic("implement me!")
 }

--- a/pkg/skoop/plugin/calico.go
+++ b/pkg/skoop/plugin/calico.go
@@ -329,6 +329,7 @@ func newCalicoHost(ipCache *k8s.IPCache, nodeInfo *k8s.NodeInfo, infraShim netwo
 		ipPools:          options.IPPools,
 		net:              assertion,
 		k8s:              k8sAssertion,
+		infraShim:        infraShim,
 	}
 
 	err := host.initRoute()
@@ -408,7 +409,7 @@ func (h *calicoHost) transmissionToPod(pkt *model.Packet, pod *v1.Pod, iif strin
 	return h.transmissionToNode(pkt, node, iif)
 }
 
-func (h *calicoHost) transmissionToNode(pkt *model.Packet, node *v1.Node, iif string) (model.Transmission, error) {
+func (h *calicoHost) transmissionToNode(pkt *model.Packet, node *v1.Node, _ string) (model.Transmission, error) {
 	err := h.checkRoute(pkt)
 	if err != nil {
 		return model.Transmission{}, err
@@ -463,7 +464,7 @@ func (h *calicoHost) transmissionToNode(pkt *model.Packet, node *v1.Node, iif st
 	}, nil
 }
 
-func (h *calicoHost) transmissionToExternal(pkt *model.Packet, iif string) (model.Transmission, error) {
+func (h *calicoHost) transmissionToExternal(pkt *model.Packet, _ string) (model.Transmission, error) {
 	err := h.checkRoute(pkt)
 	if err != nil {
 		return model.Transmission{}, err

--- a/pkg/skoop/plugin/flannel.go
+++ b/pkg/skoop/plugin/flannel.go
@@ -515,7 +515,7 @@ func (h *flannelHost) transmissionToPod(pkt *model.Packet, pod *v1.Pod, iif stri
 	return h.transmissionToNode(pkt, node, iif)
 }
 
-func (h *flannelHost) transmissionToNode(pkt *model.Packet, node *v1.Node, iif string) (model.Transmission, error) {
+func (h *flannelHost) transmissionToNode(pkt *model.Packet, node *v1.Node, _ string) (model.Transmission, error) {
 	pktOut := pkt.DeepCopy()
 
 	err := h.masquerade(pktOut)
@@ -568,7 +568,7 @@ func (h *flannelHost) transmissionToNode(pkt *model.Packet, node *v1.Node, iif s
 	}, nil
 }
 
-func (h *flannelHost) transmissionToExternal(pkt *model.Packet, iif string) (model.Transmission, error) {
+func (h *flannelHost) transmissionToExternal(pkt *model.Packet, _ string) (model.Transmission, error) {
 	pktOut := pkt.DeepCopy()
 	err := h.masquerade(pktOut)
 	if err != nil {

--- a/pkg/skoop/ui/web.go
+++ b/pkg/skoop/ui/web.go
@@ -99,7 +99,7 @@ func (u *WebUI) Serve() error {
 	return http.ListenAndServe(u.address, nil)
 }
 
-func (u *WebUI) handleUI(w http.ResponseWriter, req *http.Request) {
+func (u *WebUI) handleUI(w http.ResponseWriter, _ *http.Request) {
 	args := uiArgs{
 		DiagnoseInfo: fmt.Sprintf("%s -> %s", u.ctx.TaskConfig().SourceEndpoint, u.ctx.TaskConfig().DstEndpoint),
 	}


### PR DESCRIPTION
upgrade `golangci-lint` to try to resolve failed lint workflow problem.