### PR TITLE
add global suspicion to json format and web ui

### DIFF
--- a/pkg/skoop/cmd/app.go
+++ b/pkg/skoop/cmd/app.go
@@ -47,7 +47,7 @@ func NewSkoopCmd() *cobra.Command {
 			}
 
 			if context.SkoopContext.UIConfig().HTTP {
-				klog.Fatalf("http server exited: %s", serveWebUI(packetPath))
+				klog.Fatalf("http server exited: %s", serveWebUI(globalSuspicion, packetPath))
 			}
 
 			if context.SkoopContext.UIConfig().Format != "" {
@@ -58,7 +58,7 @@ func NewSkoopCmd() *cobra.Command {
 						klog.Fatalf("save graph file error: %v", err)
 					}
 				case "json":
-					err = saveJSONFile(packetPath)
+					err = saveJSONFile(globalSuspicion, packetPath)
 					if err != nil {
 						klog.Fatalf("save json file error: %v", err)
 					}
@@ -137,8 +137,8 @@ func saveGraphFile(p *model.PacketPath) error {
 	return nil
 }
 
-func saveJSONFile(p *model.PacketPath) error {
-	formatter := ui.NewJSONFormatter(p)
+func saveJSONFile(globalSuspicions []model.Suspicion, p *model.PacketPath) error {
+	formatter := ui.NewJSONFormatter(globalSuspicions, p)
 	data, err := formatter.ToJSON()
 	if err != nil {
 		return err
@@ -166,8 +166,8 @@ func saveJSONFile(p *model.PacketPath) error {
 	return err
 }
 
-func serveWebUI(p *model.PacketPath) error {
-	web, err := ui.NewWebUI(context.SkoopContext, p, context.SkoopContext.UIConfig().HTTPAddress)
+func serveWebUI(globalSuspicions []model.Suspicion, p *model.PacketPath) error {
+	web, err := ui.NewWebUI(context.SkoopContext, globalSuspicions, p, context.SkoopContext.UIConfig().HTTPAddress)
 	if err != nil {
 		return err
 	}

--- a/pkg/skoop/ui/html/index.html
+++ b/pkg/skoop/ui/html/index.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html>
-
 <head>
     <title>Skoop: {{.DiagnoseInfo}} </title>
 
@@ -22,6 +21,7 @@
         }
 
 
+        let cluster_info = JSON.parse('{{.Cluster}}')
         let node_info = JSON.parse('{{.Nodes}}')
         let edge_info = JSON.parse('{{.Edges}}')
 
@@ -42,14 +42,19 @@
             header.innerHTML = title
 
             let panel_info = side.querySelector(".side-panel-info")
-            let info_inner = ""
-            info.forEach(i => {
-                info_inner += `<div class="side-panel-info-item">
+            if (info.length !== 0) {
+                let info_inner = ""
+                info.forEach(i => {
+                    info_inner += `<div class="side-panel-info-item">
                         <div class="side-panel-info-item-name">${i[0]}</div>
                         <div class="side-panel-info-item-value">${i[1]}</div>
                     </div>`
-            });
-            panel_info.innerHTML = info_inner
+                });
+                panel_info.innerHTML = info_inner
+            } else {
+                panel_info.style.display = "none"
+            }
+
 
             let panel_suspicion = side.querySelector(".side-panel-suspicion")
             if (show_suspicions) {
@@ -101,6 +106,19 @@
         }
 
 
+        function applyCluster() {
+            cluster_suspicion = document.getElementById("cluster-suspicions")
+            cluster_suspicion.onclick = ev => {
+                showSlidePanel(`Cluster`, [], cluster_info.suspicions, true)
+            }
+
+            counter = `<span style="display: inline-block; text-align: center;"
+                             class="node-suspicion-counter color-${cluster_info.suspicion_level.toLowerCase()}">
+                                ${cluster_info.suspicions ? cluster_info.suspicions.length : 0}
+                       </span>`
+            cluster_suspicion.innerHTML += counter
+        }
+
         function applyNodes() {
             node_info.forEach(n => {
                 let node = document.getElementById(n.id)
@@ -136,6 +154,7 @@
 
         document.addEventListener("DOMContentLoaded", _ => {
             init()
+            applyCluster()
             applyNodes()
             applyEdges()
         })
@@ -211,7 +230,7 @@
             font-size: 12px;
             height: 16px;
             width: 16px;
-            border: 1px soild gray;
+            border: 1px gray;
             border-radius: 3px;
         }
 
@@ -329,12 +348,23 @@
             line-break: loose;
             font-size: 15px;
         }
+
+        #cluster-suspicions {
+            cursor: pointer;
+            margin-left: 10px;
+            padding: 3px;
+            border: 1px solid #fafafa;
+            border-radius: 7px;
+        }
     </style>
 </head>
 
 <body>
     <header class="skoop-header">
         <div id="title">Skoop {{.DiagnoseInfo}}</div>
+        <div id="cluster-suspicions">
+            <span>Cluster Suspicions</span>
+        </div>
     </header>
     <div id="diagnose-result">
         <div id="graph">{{.GraphSvg}}</div>
@@ -348,7 +378,6 @@
             <div class="side-panel-suspicion">
                 <div class="side-panel-suspicion-header">Suspicions:</div>
                 <div class="side-panel-suspicion-items">
-
                 </div>
             </div>
         </div>

--- a/test/skoop/e2e/framework/framework.go
+++ b/test/skoop/e2e/framework/framework.go
@@ -564,7 +564,7 @@ func (f *Framework) Assert() error {
 
 func (f *Framework) assertSuspicions(idMap map[string]string) error {
 	foundSuspicion := false
-	actualSuspicions := map[string][]ui.DiagnoseSummaryNodeSuspicion{}
+	actualSuspicions := map[string][]ui.DiagnoseSummarySuspicion{}
 	for _, n := range f.result.Summary.Nodes {
 		actualSuspicions[n.ID] = n.Suspicions
 		if len(n.Suspicions) != 0 {
@@ -573,7 +573,7 @@ func (f *Framework) assertSuspicions(idMap map[string]string) error {
 	}
 
 	if f.spec.Assertion.NoSuspicion && foundSuspicion {
-		suspicions := lo.SliceToMap(f.result.Summary.Nodes, func(n ui.DiagnoseSummaryNode) (string, []ui.DiagnoseSummaryNodeSuspicion) {
+		suspicions := lo.SliceToMap(f.result.Summary.Nodes, func(n ui.DiagnoseSummaryNode) (string, []ui.DiagnoseSummarySuspicion) {
 			return n.ID, n.Suspicions
 		})
 		return fmt.Errorf("assert no suspicion, but suspicions found: %+v", suspicions)
@@ -590,7 +590,7 @@ func (f *Framework) assertSuspicions(idMap map[string]string) error {
 			return fmt.Errorf("cannot find actual node for skoop id %s", skoopID)
 		}
 
-		_, found := lo.Find(suspicions, func(actual ui.DiagnoseSummaryNodeSuspicion) bool {
+		_, found := lo.Find(suspicions, func(actual ui.DiagnoseSummarySuspicion) bool {
 			return actual.Level == s.Level && strings.Contains(actual.Message, s.Contains)
 		})
 


### PR DESCRIPTION
fixes #61 
NetworkPolicy problems are considered as cluster-wide suspicions. But they're not be displayed in json format or Web UI.
This adds cluster-wide info to them.

![image](https://github.com/alibaba/kubeskoop/assets/3164435/bd9200de-611d-4390-8323-b9fd326782ad)
