### PR TITLE
fix(exporter): fix label out of order in mergeLabels

### DIFF
--- a/pkg/exporter/probe/metrics.go
+++ b/pkg/exporter/probe/metrics.go
@@ -244,9 +244,8 @@ func mergeArray(labels []string, labels2 []string) []string {
 	}
 
 	var ret []string
-	for k := range m {
-		ret = append(ret, k)
-	}
+	ret = append(ret, labels...)
+	ret = append(ret, labels2...)
 
 	return ret
 }


### PR DESCRIPTION
This pull request fixes the incorrect label of  `kubeskoop_flow_*` metrics.