### PR TITLE
Separate GetAllUniqueNetNSEntity and GetAllEntity

### DIFF
--- a/pkg/exporter/nettop/cache.go
+++ b/pkg/exporter/nettop/cache.go
@@ -392,25 +392,25 @@ func cacheNetTopology(ctx context.Context) error {
 			continue
 		}
 
-		if sandboxStatus.Status.Network == nil || sandboxStatus.Status.Network.Ip == "" {
-			log.Errorf("sanbox %s/%s: invalid sandbox status, no ip", sandbox.Metadata.Namespace, sandbox.Metadata.Name)
-			continue
-		}
+		hostNetwork := sandboxStatus.Status.Network == nil
 
 		e := &Entity{
 			netnsMeta: netnsMeta{
 				inum:          netnsNum,
 				mountPath:     fmt.Sprintf("/proc/%d/ns/net", info.Pid),
-				isHostNetwork: false,
+				isHostNetwork: hostNetwork,
 				ipList:        []string{status.Network.Ip},
 			},
 			podMeta: podMeta{
 				name:      name,
 				namespace: namespace,
-				ip:        sandboxStatus.Status.Network.Ip,
 			},
 			initPid: info.Pid,
 			pids:    pids,
+		}
+
+		if !hostNetwork {
+			e.ip = sandboxStatus.Status.Network.Ip
 		}
 
 		addEntityToCache(e)

--- a/pkg/exporter/probe/nlconntrack/conntrackevents.go
+++ b/pkg/exporter/probe/nlconntrack/conntrackevents.go
@@ -49,7 +49,7 @@ func (p *conntrackEventProbe) Start(ctx context.Context) error {
 		select {
 		case <-ticker.C:
 			slog.Ctx(ctx).Info("start update netns list", "module", probeName)
-			ets := nettop.GetAllEntity()
+			ets := nettop.GetAllUniqueNetNSEntity()
 			for _, et := range ets {
 				if et == nil {
 					slog.Ctx(ctx).Info("skip empty entity", "module", probeName)

--- a/pkg/exporter/probe/nlqdisc/nlqdiscstats.go
+++ b/pkg/exporter/probe/nlqdisc/nlqdiscstats.go
@@ -83,7 +83,7 @@ func (p *Probe) CollectOnce() (map[string]map[uint32]uint64, error) {
 		resMap[metric] = make(map[uint32]uint64)
 	}
 
-	ets := nettop.GetAllEntity()
+	ets := nettop.GetAllUniqueNetNSEntity()
 	for _, et := range ets {
 		stats, err := getQdiscStats(et)
 		if err != nil {

--- a/pkg/exporter/probe/procio/procio.go
+++ b/pkg/exporter/probe/procio/procio.go
@@ -57,13 +57,13 @@ func (s *ProcIO) CollectOnce() (map[string]map[uint32]uint64, error) {
 	return collect(ets)
 }
 
-func collect(_ []*nettop.Entity) (map[string]map[uint32]uint64, error) {
+func collect(ets []*nettop.Entity) (map[string]map[uint32]uint64, error) {
 	resMap := make(map[string]map[uint32]uint64)
 	for _, stat := range IOMetrics {
 		resMap[stat] = map[uint32]uint64{}
 	}
 
-	procios, err := getAllProcessIO(nettop.GetAllEntity())
+	procios, err := getAllProcessIO(ets)
 	if err != nil {
 		return resMap, err
 	}

--- a/pkg/exporter/probe/procnetdev/procnetdev.go
+++ b/pkg/exporter/probe/procnetdev/procnetdev.go
@@ -50,7 +50,7 @@ func (s *ProcNetdev) Stop(_ context.Context) error {
 }
 
 func (s *ProcNetdev) CollectOnce() (map[string]map[uint32]uint64, error) {
-	ets := nettop.GetAllEntity()
+	ets := nettop.GetAllUniqueNetNSEntity()
 	if len(ets) == 0 {
 		log.Errorf("%s error, no entity found", probeName)
 	}

--- a/pkg/exporter/probe/procnetstat/procnetstat.go
+++ b/pkg/exporter/probe/procnetstat/procnetstat.go
@@ -118,7 +118,7 @@ func (s *ProcNetstat) Stop(_ context.Context) error {
 }
 
 func (s *ProcNetstat) CollectOnce() (map[string]map[uint32]uint64, error) {
-	ets := nettop.GetAllEntity()
+	ets := nettop.GetAllUniqueNetNSEntity()
 	if len(ets) == 0 {
 		log.Errorf("%s error, no entity found", probeName)
 	}

--- a/pkg/exporter/probe/procsnmp/procsnmp.go
+++ b/pkg/exporter/probe/procsnmp/procsnmp.go
@@ -141,7 +141,7 @@ func (c *snmpCache) reload() {
 }
 
 func collect() (map[string]map[string]map[uint32]uint64, error) {
-	entitys := nettop.GetAllEntity()
+	entitys := nettop.GetAllUniqueNetNSEntity()
 
 	res := make(map[string]map[string]map[uint32]uint64)
 

--- a/pkg/exporter/probe/procsoftnet/procsoftnet.go
+++ b/pkg/exporter/probe/procsoftnet/procsoftnet.go
@@ -52,7 +52,7 @@ func (s *ProcSoftnet) Stop(_ context.Context) error {
 }
 
 func (s *ProcSoftnet) CollectOnce() (map[string]map[uint32]uint64, error) {
-	ets := nettop.GetAllEntity()
+	ets := nettop.GetAllUniqueNetNSEntity()
 	if len(ets) == 0 {
 		slog.Info("collect", "mod", probeName, "ignore", "no entity found")
 	}

--- a/pkg/exporter/probe/proctcpsummary/proctcp.go
+++ b/pkg/exporter/probe/proctcpsummary/proctcp.go
@@ -96,7 +96,7 @@ func (s *ProcTCP) Stop(_ context.Context) error {
 }
 
 func (s *ProcTCP) CollectOnce() (map[string]map[uint32]uint64, error) {
-	ets := nettop.GetAllEntity()
+	ets := nettop.GetAllUniqueNetNSEntity()
 	if len(ets) == 0 {
 		log.Infof("failed collect tcp summary, no entity found")
 	}

--- a/pkg/exporter/probe/tracepacketloss/packetloss.go
+++ b/pkg/exporter/probe/tracepacketloss/packetloss.go
@@ -208,7 +208,7 @@ func (p *packetLossProbe) collect() (map[string]map[uint32]uint64, error) {
 	)
 
 	// if no entity found, do not report metric
-	ets := nettop.GetAllEntity()
+	ets := nettop.GetAllUniqueNetNSEntity()
 	if len(ets) == 0 {
 		return resMap, nil
 	}


### PR DESCRIPTION
GetAllUniqueNetNSEntity returns entities that has unique network namespace (exclude host network pods) 
GetAllEntity returns all entities include host network pods

Probes that collect all pods data should call GetAllEntity to get all pods info. Probes that collect only network data should call GetAllUniqueNetNSEntity.