### PR TITLE
fix: fail to load probe netiftxlat

### DIFF
--- a/pkg/exporter/probe/tracenetiftxlatency/tracenetiftxlatency.go
+++ b/pkg/exporter/probe/tracenetiftxlatency/tracenetiftxlatency.go
@@ -250,7 +250,7 @@ func (p *netifTxlatencyProbe) loadAndAttachBPF() error {
 	}
 
 	// 获取Loaded的程序/map的fd信息
-	if err := loadBpfObjects(p.objs, &opts); err != nil {
+	if err := loadBpfObjects(&p.objs, &opts); err != nil {
 		return fmt.Errorf("loading objects: %v", err)
 	}
 


### PR DESCRIPTION
netiftxlat probe won't be loaded correcotly, errors like:

```text
INFO[0230] reload config, old config: null, new config: [{"name":"netiftxlat","args":null}]
INFO[0230] create metrics probe netiftxlat with args null
INFO[0230] start metrics probe netiftxlat
2024/02/14 12:08:05 INFO btf file loaded file=/sys/kernel/btf/vmlinux
ERRO[0232] netiftxlat failed load and attach bpf, err: loading objects: tracenetif.bpfObjects is not a pointer to struct
ERRO[0232] failed start probe netiftxlat, err: netiftxlat failed load bpf: loading objects: tracenetif.bpfObjects is not a pointer to struct
```