### PR TITLE
chore(build): specify 3.19 as alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /webconsole
 ADD ./webui /webconsole
 RUN yarn install && yarn build
 
-FROM docker.io/library/alpine
+FROM docker.io/library/alpine:3.19
 ARG GOPROXY
 ARG ALPINE_MIRROR
 ENV GOPROXY=$GOPROXY


### PR DESCRIPTION
Specify `3.19` alpine version in `Dockerfile` to improve build consistency.

And package `iptables-legacy` does not exist in base image version < `3.19`.