### PR TITLE
remove packetloss metrics probe args in net-exporter-config.yaml

### DIFF
--- a/deploy/net-exporter-config.yaml
+++ b/deploy/net-exporter-config.yaml
@@ -14,8 +14,6 @@ metrics:
   - name: udp
   - name: kernellatency
   - name: packetloss
-    args:
-      enableStack: false
   - name: flow
     args:
       enablePortInLabel: false


### PR DESCRIPTION
metrics probe packetloss doesn't support `enableStack` args (event probe packetloss does), so remove it in example config file