### PR TITLE
deprecate legacy metrics labels

### DIFF
--- a/pkg/exporter/probe/tracekernel/tracekernel.go
+++ b/pkg/exporter/probe/tracekernel/tracekernel.go
@@ -243,7 +243,7 @@ func (p *kernelLatencyProbe) perfLoop() {
 		netns := event.SkbMeta.Netns
 		evt := &probe.Event{
 			Timestamp: time.Now().UnixNano(),
-			Labels:    probe.LagacyEventLabels(netns),
+			Labels:    probe.LegacyEventLabels(netns),
 		}
 		/*
 		   #define RX_KLATENCY 1

--- a/pkg/exporter/probe/tracenetiftxlatency/tracenetiftxlatency.go
+++ b/pkg/exporter/probe/tracenetiftxlatency/tracenetiftxlatency.go
@@ -208,7 +208,7 @@ func (p *netifTxlatencyProbe) perfLoop() {
 
 		evt := &probe.Event{
 			Timestamp: time.Now().UnixNano(),
-			Labels:    probe.LagacyEventLabels(event.SkbMeta.Netns),
+			Labels:    probe.LegacyEventLabels(event.SkbMeta.Netns),
 		}
 		tuple := fmt.Sprintf("protocol=%s saddr=%s sport=%d daddr=%s dport=%d ", bpfutil.GetProtoStr(event.Tuple.L4Proto), bpfutil.GetAddrStr(event.Tuple.L3Proto, *(*[16]byte)(unsafe.Pointer(&event.Tuple.Saddr))), bits.ReverseBytes16(event.Tuple.Sport), bpfutil.GetAddrStr(event.Tuple.L3Proto, *(*[16]byte)(unsafe.Pointer(&event.Tuple.Daddr))), bits.ReverseBytes16(event.Tuple.Dport))
 		evt.Message = fmt.Sprintf("%s latency:%s", tuple, bpfutil.GetHumanTimes(event.Latency))

--- a/pkg/exporter/probe/tracesocketlatency/socketlatency.go
+++ b/pkg/exporter/probe/tracesocketlatency/socketlatency.go
@@ -211,7 +211,7 @@ func (p *socketLatencyProbe) perfLoop() {
 		}
 		evt := &probe.Event{
 			Timestamp: time.Now().UnixNano(),
-			Labels:    probe.LagacyEventLabels(event.SkbMeta.Netns),
+			Labels:    probe.LegacyEventLabels(event.SkbMeta.Netns),
 		}
 		/*
 			#define ACTION_READ	    1

--- a/pkg/exporter/probe/tracetcpreset/tracetcpreset.go
+++ b/pkg/exporter/probe/tracetcpreset/tracetcpreset.go
@@ -128,7 +128,7 @@ func (p *tcpResetProbe) perfLoop() {
 		evt := &probe.Event{
 			Timestamp: time.Now().UnixNano(),
 			Type:      eventType,
-			Labels:    probe.LagacyEventLabels(event.SkbMeta.Netns),
+			Labels:    probe.LegacyEventLabels(event.SkbMeta.Netns),
 		}
 
 		tuple := fmt.Sprintf("protocol=%s saddr=%s sport=%d daddr=%s dport=%d ", bpfutil.GetProtoStr(event.Tuple.L4Proto), bpfutil.GetAddrStr(event.Tuple.L3Proto, *(*[16]byte)(unsafe.Pointer(&event.Tuple.Saddr))), bits.ReverseBytes16(event.Tuple.Sport), bpfutil.GetAddrStr(event.Tuple.L3Proto, *(*[16]byte)(unsafe.Pointer(&event.Tuple.Daddr))), bits.ReverseBytes16(event.Tuple.Dport))


### PR DESCRIPTION
From now on, all metrics whose name start with 'inspect_' are not supported. 

The new metrics only have three labels (k8s_namespace, k8s_pod and k8s_node)

