### PR TITLE
Feature/unixsock

### DIFF
--- a/pkg/exporter/cmd/config.go
+++ b/pkg/exporter/cmd/config.go
@@ -8,8 +8,12 @@ import (
 )
 
 type InspServerConfig struct {
-	DebugMode        bool          `yaml:"debugMode" mapstructure:"debugMode" json:"debugMode"`
-	Port             uint16        `yaml:"port" mapstructure:"port" json:"port"`
+	DebugMode bool `yaml:"debugMode" mapstructure:"debugMode" json:"debugMode"`
+	// A better way to set listen port is a `address` field  that can be used for bind interface ip, or even unix domain socket
+	// Deprecated: use address instead
+	Port uint16 `yaml:"port" mapstructure:"port" json:"port"`
+
+	Address          string        `yaml:"address" mapstructure:"address" json:"address"`
 	EnableController bool          `yaml:"enableController" mapstructure:"enableController" json:"enableController"`
 	MetricsConfig    MetricsConfig `yaml:"metrics" mapstructure:"metrics" json:"metrics"`
 	EventConfig      EventConfig   `yaml:"event" mapstructure:"event" json:"event"`


### PR DESCRIPTION
Support more flexible listening configuration. Use addr instead of port which is deprecated. 

Now you can use addr: `127.0.0.1:9102` to listen only on loopback or `addr: unix:///var/run/kubeskoop/server.sock` to listen on unix domain socket.

