### PR TITLE
Fix: Enhance default interface detection logic

### DIFF
--- a/pkg/skoop/netstack/link.go
+++ b/pkg/skoop/netstack/link.go
@@ -71,8 +71,8 @@ func LookupDefaultIfaceName(ifaces []Interface) string {
 		}
 	}
 
-	// find first interfaces matched enp[0-9]+s[0-9]+.*
-	regex := regexp.MustCompile("^enp[0-9]+s[0-9]+.*$")
+	// find first interfaces matched (enp[0-9]+s[0-9]+.*|eth[0-9]+|ens[0-9]+)$")
+	regex := regexp.MustCompile("^(enp[0-9]+s[0-9]+.*|eth[0-9]+|ens[0-9]+)$")
 	filtered := lo.Filter(ifaces, func(i Interface, _ int) bool {
 		return regex.MatchString(i.Name)
 	})

--- a/pkg/skoop/netstack/link_test.go
+++ b/pkg/skoop/netstack/link_test.go
@@ -24,6 +24,10 @@ func TestLookupDefaultIfaceName(t *testing.T) {
 			ifaces:   []string{"wg0", "ipvs0", "cni0", "aaenp1s1"},
 			expected: "",
 		},
+		{
+			ifaces:   []string{"ens160", "cali85f094c216c", "vxlan.calico", "calie92c3084733"},
+			expected: "ens160",
+		},
 	}
 
 	for _, c := range testcases {


### PR DESCRIPTION
**Solution:**
- Updated 'LookupDefaultIfaceName' to support additional naming conventions such as 'ens[0-9]+.*' and 'eth[0-9]+'.

**Related Issue:**
Fixes the error: 'cannot lookup default host interface, please manually specify it via --calico-host-interface'.
#322 

**Test plan:**
- Tested with interfaces named 'ens162', 'ens192', 'eth0', and 'lo'.
"
