### PR TITLE
Fix/addnodes skip empty ip

### DIFF
--- a/pkg/controller/graph/graph.go
+++ b/pkg/controller/graph/graph.go
@@ -105,19 +105,23 @@ func (g *FlowGraph) AddNodesFromVector(v model.Vector) {
 }
 
 func (g *FlowGraph) AddNodesFromSample(v *model.Sample) {
-	ip := string(v.Metric["src"])
-	t := string(v.Metric["src_type"])
-	podName := string(v.Metric["src_pod"])
-	podNamespace := string(v.Metric["src_namespace"])
-	nodeName := string(v.Metric["src_node"])
-	g.AddNode(createNode(t, ip, podNamespace, podName, nodeName))
+	srcIP := string(v.Metric["src"])
+	if srcIP != "" {
+		t := string(v.Metric["src_type"])
+		podName := string(v.Metric["src_pod"])
+		podNamespace := string(v.Metric["src_namespace"])
+		nodeName := string(v.Metric["src_node"])
+		g.AddNode(createNode(t, srcIP, podNamespace, podName, nodeName))
+	}
 
-	ip = string(v.Metric["dst"])
-	t = string(v.Metric["dst_type"])
-	podName = string(v.Metric["dst_pod"])
-	podNamespace = string(v.Metric["dst_namespace"])
-	nodeName = string(v.Metric["dst_node"])
-	g.AddNode(createNode(t, ip, podNamespace, podName, nodeName))
+	dstIP := string(v.Metric["dst"])
+	if dstIP != "" {
+		t := string(v.Metric["dst_type"])
+		podName := string(v.Metric["dst_pod"])
+		podNamespace := string(v.Metric["dst_namespace"])
+		nodeName := string(v.Metric["dst_node"])
+		g.AddNode(createNode(t, dstIP, podNamespace, podName, nodeName))
+	}
 }
 
 func (g *FlowGraph) AddNode(n Node) {


### PR DESCRIPTION
**Solution:**
- Added validation to check if `src` or `dst` IP fields are non-empty before creating and adding nodes to the graph.
- Ensured that no nodes are created when IPs are missing, preventing invalid graph entries.

**Related Issue:**
Fixes invalid node addition when IPs are empty in the `FlowGraph` implementation.
#327 

**Test plan:**
- Tested with valid `src` and `dst` IPs to ensure nodes are created as expected.
- Verified no nodes are created for samples with empty `src` or `dst` IPs.
- Tested mixed cases where either `src` or `dst` is empty, ensuring only valid nodes are added."