### PR TITLE
Optimize exporter CPU and memory usage for high-density nodes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,11 +42,11 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
-	github.com/stretchr/testify v1.8.3
+	github.com/stretchr/testify v1.10.0
 	github.com/ti-mo/conntrack v0.4.0
 	github.com/ti-mo/netfilter v0.5.0
-	github.com/vishvananda/netlink v1.2.1-beta.2
-	github.com/vishvananda/netns v0.0.4
+	github.com/vishvananda/netlink v1.3.2-0.20260404173425-c822ed716ea1
+	github.com/vishvananda/netns v0.0.5
 	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2
 	golang.org/x/sync v0.11.0
 	golang.org/x/sys v0.30.0
@@ -171,7 +171,7 @@ require (
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/rivo/uniseg v0.4.3 // indirect
 	github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980 // indirect
-	github.com/stretchr/objx v0.5.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/tchap/go-patricia v2.2.6+incompatible // indirect
 	github.com/tetratelabs/wazero v1.9.0 // indirect
 	github.com/tjfoc/gmsm v1.3.2 // indirect
@@ -210,5 +210,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-replace github.com/vishvananda/netlink v1.2.1-beta.2 => github.com/bswang/netlink v1.0.1-0.20240423021740-86cd4b5bb65d

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,6 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
-github.com/bswang/netlink v1.0.1-0.20240423021740-86cd4b5bb65d h1:v/jMfwlqJxCqdVtcNIiHwKDnfTBWGjNWFbfS+HYuFfc=
-github.com/bswang/netlink v1.0.1-0.20240423021740-86cd4b5bb65d/go.mod h1:whJevzBpTrid75eZy99s3DqCmy05NfibNaF2Ol5Ox5A=
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
@@ -1101,8 +1099,9 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v0.0.0-20180303142811-b89eecf5ca5d/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -1114,8 +1113,9 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
@@ -1150,12 +1150,14 @@ github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
 github.com/vishvananda/netlink v1.1.1-0.20210330154013-f5de75959ad5/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
+github.com/vishvananda/netlink v1.3.2-0.20260404173425-c822ed716ea1 h1:Ghi0XnIPOg5XHWZa/YPPA9JJBAYWSgYNcnxDpisN1Tk=
+github.com/vishvananda/netlink v1.3.2-0.20260404173425-c822ed716ea1/go.mod h1:lEui7SPMd9fgxzHVGRAvTxsBGCF6PRH81o2kLWLWHgw=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
-github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=
-github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
+github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zdEY=
+github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
@@ -1507,7 +1509,6 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=

--- a/pkg/exporter/bpfutil/kallsyms.go
+++ b/pkg/exporter/bpfutil/kallsyms.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/cilium/ebpf"
 	"github.com/hashicorp/golang-lru/v2/expirable"
@@ -34,15 +35,22 @@ func (k *KernelSymbol) GetExpr() string {
 }
 
 var kallsyms []KernelSymbol
+var kallsymsOnce sync.Once
+var kallsymsErr error
 
-func init() {
-	kallsyms = []KernelSymbol{}
-	if err := getAllSyms(); err != nil {
-		return
-	}
+func ensureKallsyms() error {
+	kallsymsOnce.Do(func() {
+		kallsyms = []KernelSymbol{}
+		kallsymsErr = getAllSyms()
+	})
+	return kallsymsErr
 }
 
 func GetSymByPt(addr string) (*KernelSymbol, error) {
+	if err := ensureKallsyms(); err != nil {
+		return nil, fmt.Errorf("load kallsyms: %w", err)
+	}
+
 	var pt uint64
 	if strings.HasPrefix(addr, "0x") {
 		addr = addr[2:]
@@ -83,6 +91,10 @@ var locationCache = expirable.NewLRU[uint64, KernelSymbol](100, nil, 0)
 
 // GetSymPtFromBpfLocation return symbol struct/offset/error with bpf location
 func GetSymPtFromBpfLocation(pt uint64) (*KernelSymbol, error) {
+	if err := ensureKallsyms(); err != nil {
+		return nil, fmt.Errorf("load kallsyms: %w", err)
+	}
+
 	sym, ok := locationCache.Get(pt)
 	if ok {
 		return &sym, nil

--- a/pkg/exporter/cmd/server.go
+++ b/pkg/exporter/cmd/server.go
@@ -74,6 +74,12 @@ var (
 
 			defer nettop.StopCache()
 
+			if err = nettop.StartLinkManager(); err != nil {
+				log.Errorf("failed start link manager: %v", err)
+				return
+			}
+			defer nettop.StopLinkManager()
+
 			if cfg.EnableController {
 				if cfg.ControllerAddr == "" {
 					log.Infof("controller address is empty, use dns:controller:10263 as default")

--- a/pkg/exporter/nettop/linkmanager.go
+++ b/pkg/exporter/nettop/linkmanager.go
@@ -1,0 +1,270 @@
+package nettop
+
+import (
+	"sync"
+	"syscall"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+)
+
+// LinkInfo is a snapshot of a network interface.
+type LinkInfo struct {
+	Index int
+	Name  string
+	Link  netlink.Link
+}
+
+// LinkEventType distinguishes add from delete events.
+type LinkEventType int
+
+const (
+	LinkAdded LinkEventType = iota
+	LinkDeleted
+)
+
+// LinkEvent represents a single link change.
+type LinkEvent struct {
+	Type LinkEventType
+	Info LinkInfo
+}
+
+// LinkListener receives notifications on interface changes.
+type LinkListener interface {
+	OnLinkAdd(info LinkInfo)
+	OnLinkDel(info LinkInfo)
+}
+
+// listenerEntry holds a registered listener with its dedicated event channel.
+type listenerEntry struct {
+	listener LinkListener
+	ch       chan LinkEvent
+	done     chan struct{}
+}
+
+type linkManager struct {
+	links   map[int]LinkInfo // ifIndex -> LinkInfo
+	entries []*listenerEntry
+	mu      sync.RWMutex
+	done    chan struct{}
+}
+
+var defaultLinkManager *linkManager
+
+// StartLinkManager initialises the global link manager: populates the
+// initial link cache and starts a netlink subscription for changes.
+func StartLinkManager() error {
+	m := &linkManager{
+		links: make(map[int]LinkInfo),
+		done:  make(chan struct{}),
+	}
+
+	links, err := netlink.LinkList()
+	if err != nil {
+		return err
+	}
+	for _, l := range links {
+		m.links[l.Attrs().Index] = LinkInfo{
+			Index: l.Attrs().Index,
+			Name:  l.Attrs().Name,
+			Link:  l,
+		}
+	}
+
+	ch := make(chan netlink.LinkUpdate)
+	if err := netlink.LinkSubscribe(ch, m.done); err != nil {
+		return err
+	}
+
+	go m.eventLoop(ch)
+
+	defaultLinkManager = m
+	return nil
+}
+
+// StopLinkManager shuts down the global link manager.
+func StopLinkManager() {
+	m := defaultLinkManager
+	if m == nil {
+		return
+	}
+	close(m.done)
+
+	m.mu.Lock()
+	for _, entry := range m.entries {
+		close(entry.done)
+	}
+	m.entries = nil
+	m.mu.Unlock()
+
+	defaultLinkManager = nil
+}
+
+// eventLoop processes netlink link updates.
+func (m *linkManager) eventLoop(ch <-chan netlink.LinkUpdate) {
+	for {
+		select {
+		case update, ok := <-ch:
+			if !ok {
+				return
+			}
+			m.handleUpdate(update)
+		case <-m.done:
+			return
+		}
+	}
+}
+
+func (m *linkManager) handleUpdate(update netlink.LinkUpdate) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	index := update.Attrs().Index
+	name := update.Attrs().Name
+
+	switch update.Header.Type {
+	case syscall.RTM_NEWLINK:
+		info := LinkInfo{
+			Index: index,
+			Name:  name,
+			Link:  update.Link,
+		}
+		m.links[index] = info
+		m.broadcast(LinkEvent{Type: LinkAdded, Info: info})
+
+	case syscall.RTM_DELLINK:
+		info, ok := m.links[index]
+		if !ok {
+			info = LinkInfo{Index: index, Name: name}
+		}
+		delete(m.links, index)
+		m.broadcast(LinkEvent{Type: LinkDeleted, Info: info})
+	}
+}
+
+// broadcast sends an event to every registered listener channel.
+// Must be called with m.mu held (write lock).
+func (m *linkManager) broadcast(ev LinkEvent) {
+	for _, entry := range m.entries {
+		select {
+		case entry.ch <- ev:
+		default:
+			log.Warnf("linkmanager: event channel full for listener, dropping event")
+		}
+	}
+}
+
+// RegisterLinkListener adds a listener and replays all existing links as
+// LinkAdded events. Replay events and future netlink events are both
+// delivered through the listener's dedicated channel, ensuring strict
+// ordering and no event loss.
+func RegisterLinkListener(l LinkListener) {
+	m := defaultLinkManager
+	if m == nil {
+		log.Warnf("linkmanager: RegisterLinkListener called before StartLinkManager")
+		return
+	}
+	m.registerListener(l)
+}
+
+func (m *linkManager) registerListener(l LinkListener) {
+	m.mu.Lock()
+
+	entry := &listenerEntry{
+		listener: l,
+		ch:       make(chan LinkEvent, len(m.links)+1024),
+		done:     make(chan struct{}),
+	}
+
+	// Enqueue replay events for all existing links while holding lock,
+	// so no netlink event can slip between snapshot and subscribe.
+	for _, info := range m.links {
+		entry.ch <- LinkEvent{Type: LinkAdded, Info: info}
+	}
+
+	m.entries = append(m.entries, entry)
+	m.mu.Unlock()
+
+	// Start dispatch goroutine for this listener.
+	go func() {
+		for {
+			select {
+			case ev := <-entry.ch:
+				switch ev.Type {
+				case LinkAdded:
+					l.OnLinkAdd(ev.Info)
+				case LinkDeleted:
+					l.OnLinkDel(ev.Info)
+				}
+			case <-entry.done:
+				return
+			}
+		}
+	}()
+}
+
+// UnregisterLinkListener removes a previously registered listener and
+// stops its dispatch goroutine.
+func UnregisterLinkListener(l LinkListener) {
+	m := defaultLinkManager
+	if m == nil {
+		return
+	}
+	m.unregisterListener(l)
+}
+
+func (m *linkManager) unregisterListener(l LinkListener) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i, entry := range m.entries {
+		if entry.listener == l {
+			close(entry.done)
+			m.entries = append(m.entries[:i], m.entries[i+1:]...)
+			return
+		}
+	}
+}
+
+// --------------- Lookup API ---------------
+
+// GetLinkNameByIndex returns the cached interface name for the given index.
+func GetLinkNameByIndex(index int) (string, bool) {
+	m := defaultLinkManager
+	if m == nil {
+		return "", false
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	info, ok := m.links[index]
+	if !ok {
+		return "", false
+	}
+	return info.Name, true
+}
+
+// GetLinkByIndex returns the cached LinkInfo for the given index.
+func GetLinkByIndex(index int) (LinkInfo, bool) {
+	m := defaultLinkManager
+	if m == nil {
+		return LinkInfo{}, false
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	info, ok := m.links[index]
+	return info, ok
+}
+
+// GetAllLinks returns a snapshot of all cached links.
+func GetAllLinks() []LinkInfo {
+	m := defaultLinkManager
+	if m == nil {
+		return nil
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	ret := make([]LinkInfo, 0, len(m.links))
+	for _, info := range m.links {
+		ret = append(ret, info)
+	}
+	return ret
+}

--- a/pkg/exporter/probe/flow/flow.go
+++ b/pkg/exporter/probe/flow/flow.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/alibaba/kubeskoop/pkg/exporter/nettop"
 	"github.com/alibaba/kubeskoop/pkg/exporter/probe"
 
 	"github.com/alibaba/kubeskoop/pkg/exporter/bpfutil"
@@ -81,9 +82,26 @@ type linkFlowHelper interface {
 type dynamicLinkFlowHelper struct {
 	bpfObjs *bpfObjects
 	pattern string
-	done    chan struct{}
 	flows   map[int]*ebpfFlow
 	lock    sync.Mutex
+}
+
+func (h *dynamicLinkFlowHelper) OnLinkAdd(info nettop.LinkInfo) {
+	if !strings.HasPrefix(info.Name, h.pattern) {
+		return
+	}
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	h.tryStartLinkFlow(info.Link)
+}
+
+func (h *dynamicLinkFlowHelper) OnLinkDel(info nettop.LinkInfo) {
+	if !strings.HasPrefix(info.Name, h.pattern) {
+		return
+	}
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	h.tryStopLinkFlow(info.Name, info.Index)
 }
 
 func (h *dynamicLinkFlowHelper) tryStartLinkFlow(link netlink.Link) {
@@ -117,62 +135,18 @@ func (h *dynamicLinkFlowHelper) tryStopLinkFlow(name string, index int) {
 }
 
 func (h *dynamicLinkFlowHelper) start() error {
-	h.done = make(chan struct{})
-	ch := make(chan netlink.LinkUpdate)
-	links, err := netlink.LinkList()
-	if err != nil {
-		return fmt.Errorf("%s error list link, err: %w", probeName, err)
-	}
-	for _, link := range links {
-		if !strings.HasPrefix(link.Attrs().Name, h.pattern) {
-			continue
-		}
-		h.tryStartLinkFlow(link)
-	}
-	go func() {
-		if err := netlink.LinkSubscribe(ch, h.done); err != nil {
-			log.Errorf("%s error watch link change, err: %v", probeName, err)
-			close(h.done)
-		}
-	}()
-	go func() {
-		h.lock.Lock()
-		defer h.lock.Unlock()
-		for {
-			select {
-			case change := <-ch:
-				if !strings.HasSuffix(change.Attrs().Name, h.pattern) {
-					break
-				}
-				switch change.Header.Type {
-				case syscall.RTM_NEWLINK:
-					link, err := netlink.LinkByIndex(int(change.Index))
-					if err != nil {
-						log.Errorf("failed get new created link by index %d, name %s, err: %v", change.Index, change.Attrs().Name, err)
-						break
-					}
-					h.tryStartLinkFlow(link)
-				case syscall.RTM_DELLINK:
-					h.tryStopLinkFlow(change.Attrs().Name, int(change.Index))
-				}
-			case <-h.done:
-				return
-			}
-		}
-	}()
+	nettop.RegisterLinkListener(h)
 	return nil
 }
 
 func (h *dynamicLinkFlowHelper) stop() error {
-	close(h.done)
+	nettop.UnregisterLinkListener(h)
 	h.lock.Lock()
 	defer h.lock.Unlock()
 	var first error
 	for _, flow := range h.flows {
-		if err := flow.stop(); err != nil {
-			if first == nil {
-				first = err
-			}
+		if err := flow.stop(); err != nil && first == nil {
+			first = err
 		}
 	}
 	return first
@@ -202,7 +176,6 @@ func metricsProbeCreator(args flowArgs) (probe.MetricsProbe, error) {
 			p.helper = &dynamicLinkFlowHelper{
 				bpfObjs: &p.bpfObjs,
 				pattern: pattern,
-				done:    make(chan struct{}),
 				flows:   make(map[int]*ebpfFlow),
 			}
 		} else {

--- a/pkg/exporter/probe/nlqdisc/nlqdiscstats.go
+++ b/pkg/exporter/probe/nlqdisc/nlqdiscstats.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"net"
 	"strings"
 	"syscall"
 
@@ -127,6 +126,22 @@ func getQdiscStats(entity *nettop.Entity) ([]QdiscInfo, error) {
 	}
 	defer c.Close()
 
+	// Build interface index -> name map for this namespace.
+	var ifaceMap map[int]string
+	if entity.IsHostNetwork() {
+		allLinks := nettop.GetAllLinks()
+		ifaceMap = make(map[int]string, len(allLinks))
+		for _, l := range allLinks {
+			ifaceMap[l.Index] = l.Name
+		}
+	} else {
+		ifaceMap, err = getInterfaceMap(c)
+		if err != nil {
+			log.Warnf("%s failed get interface map for netns %d: %v", probeName, entity.GetNetns(), err)
+			ifaceMap = make(map[int]string)
+		}
+	}
+
 	req := netlink.Message{
 		Header: netlink.Header{
 			Flags: netlink.Request | netlink.Dump,
@@ -142,7 +157,7 @@ func getQdiscStats(entity *nettop.Entity) ([]QdiscInfo, error) {
 
 	res := []QdiscInfo{}
 	for _, msg := range msgs {
-		m, err := parseMessage(msg)
+		m, err := parseMessage(msg, ifaceMap)
 		if err != nil {
 			log.Errorf("failed parse qdisc msg, nlmsg: %v, err: %v", msg, err)
 			continue
@@ -151,6 +166,42 @@ func getQdiscStats(entity *nettop.Entity) ([]QdiscInfo, error) {
 	}
 
 	return res, nil
+}
+
+// getInterfaceMap queries RTM_GETLINK on an existing netlink connection
+// and returns a map of interface index to interface name.
+func getInterfaceMap(c *netlink.Conn) (map[int]string, error) {
+	req := netlink.Message{
+		Header: netlink.Header{
+			Flags: netlink.Request | netlink.Dump,
+			Type:  18, // RTM_GETLINK
+		},
+		Data: make([]byte, 16), // struct ifinfomsg
+	}
+
+	msgs, err := c.Execute(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute RTM_GETLINK request: %v", err)
+	}
+
+	ifaceMap := make(map[int]string, len(msgs))
+	for _, msg := range msgs {
+		if len(msg.Data) < 16 {
+			continue
+		}
+		ifaceIdx := int(nlenc.Uint32(msg.Data[4:8]))
+		attrs, err := netlink.UnmarshalAttributes(msg.Data[16:])
+		if err != nil {
+			continue
+		}
+		for _, attr := range attrs {
+			if attr.Type == 3 { // IFLA_IFNAME
+				ifaceMap[ifaceIdx] = nlenc.String(attr.Data)
+				break
+			}
+		}
+	}
+	return ifaceMap, nil
 }
 
 func getConn(nsfd int) (*netlink.Conn, error) {
@@ -296,7 +347,7 @@ func parseTCFqQdStats(attr netlink.Attribute) (TCFqQdStats, error) {
 }
 
 // See https://tools.ietf.org/html/rfc3549#section-3.1.3
-func parseMessage(msg netlink.Message) (QdiscInfo, error) {
+func parseMessage(msg netlink.Message, ifaceMap map[int]string) (QdiscInfo, error) {
 	var m QdiscInfo
 	var s TCStats
 	var s2 TCStats2
@@ -376,11 +427,7 @@ func parseMessage(msg netlink.Message) (QdiscInfo, error) {
 		}
 	}
 
-	iface, err := net.InterfaceByIndex(int(ifaceIdx))
+	m.IfaceName = ifaceMap[int(ifaceIdx)]
 
-	if err == nil {
-		m.IfaceName = iface.Name
-	}
-
-	return m, err
+	return m, nil
 }

--- a/pkg/exporter/probe/procnetstat/procnetstat.go
+++ b/pkg/exporter/probe/procnetstat/procnetstat.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -94,9 +93,18 @@ var (
 		{Name: PFMemallocDrop, Help: "The total number of packets dropped due to PF_MEMALLOC allocations failing."},
 		{Name: TCPWqueueTooBig, Help: "The total number of TCP send queue drops due to the queue being too large."},
 	}
+
+	// wantedFields maps lowercase field name to metric name, built once at init.
+	wantedFields map[string]string
 )
 
 func init() {
+	// Build lookup map once: lowercase field name -> metric name.
+	wantedFields = make(map[string]string, len(TCPExtMetrics))
+	for _, m := range TCPExtMetrics {
+		wantedFields[m.Name] = m.Name
+	}
+
 	probe.MustRegisterMetricsProbe(probeName, netdevProbeCreator)
 }
 
@@ -135,78 +143,90 @@ func collect(nslist []*nettop.Entity) (map[string]map[uint32]uint64, error) {
 	}
 
 	for _, et := range nslist {
-		stats, err := getNetstatByPid(uint32(et.GetPid()))
-		if err != nil {
+		nsinum := uint32(et.GetNetns())
+		netstatpath := fmt.Sprintf("/proc/%d/net/netstat", et.GetPid())
+		if err := parseNetstatDirect(netstatpath, nsinum, resMap); err != nil {
 			log.Errorf("%s failed collect pid %d, err: %v", probeName, et.GetPid(), err)
+		}
+	}
+
+	return resMap, nil
+}
+
+// parseNetstatDirect reads /proc/<pid>/net/netstat and writes wanted metrics
+// directly into resMap, avoiding intermediate map[string]map[string]string allocations.
+func parseNetstatDirect(path string, nsinum uint32, resMap map[string]map[uint32]uint64) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		headerLine := scanner.Text()
+		if !scanner.Scan() {
+			break
+		}
+		valueLine := scanner.Text()
+
+		// Only process TcpExt lines (protocol prefix before ':').
+		colonIdx := strings.IndexByte(headerLine, ':')
+		if colonIdx < 0 {
+			continue
+		}
+		protocol := strings.ToLower(headerLine[:colonIdx])
+		if protocol != ProtocolTCPExt {
 			continue
 		}
 
-		extstats := stats[ProtocolTCPExt]
-		for _, stat := range TCPExtMetrics {
-			if _, ok := extstats[stat.Name]; ok {
-				data, err := strconv.ParseUint(extstats[stat.Name], 10, 64)
-				if err != nil {
-					log.Errorf("%s failed parse stat %s, pid: %d err: %v", probeName, stat, et.GetPid(), err)
-					continue
+		// Walk both lines field-by-field without allocating slices.
+		hi := colonIdx + 1
+		vi := strings.IndexByte(valueLine, ':')
+		if vi < 0 {
+			continue
+		}
+		vi++
+
+		hLen := len(headerLine)
+		vLen := len(valueLine)
+
+		for {
+			// Skip whitespace in header
+			for hi < hLen && headerLine[hi] == ' ' {
+				hi++
+			}
+			if hi >= hLen {
+				break
+			}
+			// Find end of header field
+			hStart := hi
+			for hi < hLen && headerLine[hi] != ' ' {
+				hi++
+			}
+			fieldName := strings.ToLower(headerLine[hStart:hi])
+
+			// Skip whitespace in value
+			for vi < vLen && valueLine[vi] == ' ' {
+				vi++
+			}
+			// Find end of value field
+			vStart := vi
+			for vi < vLen && valueLine[vi] != ' ' {
+				vi++
+			}
+
+			// Only parse if this field is one we want.
+			if metricName, ok := wantedFields[fieldName]; ok {
+				if vStart < vi {
+					val, err := strconv.ParseUint(valueLine[vStart:vi], 10, 64)
+					if err == nil {
+						resMap[metricName][nsinum] += val
+					}
 				}
-				resMap[stat.Name][uint32(et.GetNetns())] += data
 			}
 		}
 	}
 
-	return resMap, nil
-}
-
-func getNetstatByPid(pid uint32) (map[string]map[string]string, error) {
-	resMap := make(map[string]map[string]string)
-	netstatpath := fmt.Sprintf("/proc/%d/net/netstat", pid)
-	if _, err := os.Stat(netstatpath); os.IsNotExist(err) {
-		return resMap, err
-	}
-
-	netStats, err := getNetStats(netstatpath)
-	if err != nil {
-		return resMap, err
-	}
-
-	for k, v := range netStats {
-		resMap[k] = v
-	}
-
-	return resMap, nil
-}
-
-func getNetStats(fileName string) (map[string]map[string]string, error) {
-	file, err := os.Open(fileName)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	return parseNetStats(file, fileName)
-}
-
-func parseNetStats(r io.Reader, fileName string) (map[string]map[string]string, error) {
-	var (
-		netStats = map[string]map[string]string{}
-		scanner  = bufio.NewScanner(r)
-	)
-
-	for scanner.Scan() {
-		nameParts := strings.Split(scanner.Text(), " ")
-		scanner.Scan()
-		valueParts := strings.Split(scanner.Text(), " ")
-		// Remove trailing :.
-		protocol := strings.ToLower(nameParts[0][:len(nameParts[0])-1])
-		netStats[protocol] = map[string]string{}
-		if len(nameParts) != len(valueParts) {
-			return nil, fmt.Errorf("mismatch field count mismatch in %s: %s",
-				fileName, protocol)
-		}
-		for i := 1; i < len(nameParts); i++ {
-			netStats[protocol][strings.ToLower(nameParts[i])] = valueParts[i]
-		}
-	}
-
-	return netStats, scanner.Err()
+	return scanner.Err()
 }

--- a/pkg/exporter/probe/procsnmp/procsnmp.go
+++ b/pkg/exporter/probe/procsnmp/procsnmp.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -137,9 +136,31 @@ var (
 	cache = &snmpCache{
 		cache: make(map[string]map[string]map[uint32]uint64),
 	}
+
+	// wantedSnmpFields: lowercase protocol -> lowercase field name -> (proto key, metric name).
+	// Built once at init to avoid per-call allocations.
+	wantedSnmpFields map[string]map[string]wantedField
 )
 
+type wantedField struct {
+	protoKey   string
+	metricName string
+}
+
 func init() {
+	// Build the lookup table once.
+	wantedSnmpFields = make(map[string]map[string]wantedField)
+	for protoKey, metricsList := range metricsMap {
+		for _, m := range metricsList {
+			// /proc/net/snmp uses "Tcp", "Udp", "Ip" as protocol prefix.
+			// After lowercasing, "tcp" maps to protoKey "tcp", etc.
+			if wantedSnmpFields[protoKey] == nil {
+				wantedSnmpFields[protoKey] = make(map[string]wantedField)
+			}
+			wantedSnmpFields[protoKey][m.Name] = wantedField{protoKey: protoKey, metricName: m.Name}
+		}
+	}
+
 	probe.MustRegisterMetricsProbe(TCP, newSnmpProbeCreator(TCP))
 	probe.MustRegisterMetricsProbe(UDP, newSnmpProbeCreator(UDP))
 	probe.MustRegisterMetricsProbe(IP, newSnmpProbeCreator(IP))
@@ -214,27 +235,10 @@ func collect() (map[string]map[string]map[uint32]uint64, error) {
 	for _, et := range entitys {
 		if et != nil {
 			pid := et.GetPid()
-			nsinum := et.GetNetns()
-
-			stats, err := getNetstatByPid(pid)
-			if err != nil {
-				log.Errorf("%s failed get netstat, pid: %d, nsinum: %d, err: %v", "snmp", pid, nsinum, err)
-				continue
-			}
-
-			for proto, stat := range stats {
-				for k, v := range stat {
-					data, err := strconv.ParseInt(v, 10, 64)
-					if err != nil {
-						log.Errorf("%s failed parse netstat value, pid: %d, nsinum: %d, key: %s value: %s, err: %v", "snmp", pid, nsinum, k, v, err)
-						continue
-					}
-					// ignore unaware metric
-
-					if _, ok := res[proto][k]; ok {
-						res[proto][k][uint32(nsinum)] = uint64(data)
-					}
-				}
+			nsinum := uint32(et.GetNetns())
+			snmppath := fmt.Sprintf("/proc/%d/net/snmp", pid)
+			if err := parseSnmpDirect(snmppath, nsinum, res); err != nil {
+				log.Errorf("snmp failed collect pid %d, nsinum %d, err: %v", pid, nsinum, err)
 			}
 		}
 	}
@@ -242,56 +246,75 @@ func collect() (map[string]map[string]map[uint32]uint64, error) {
 	return res, nil
 }
 
-func getNetstatByPid(pid int) (map[string]map[string]string, error) {
-	resMap := make(map[string]map[string]string)
-
-	snmppath := fmt.Sprintf("/proc/%d/net/snmp", pid)
-	if _, err := os.Stat(snmppath); os.IsNotExist(err) {
-		return resMap, err
-	}
-	snmpStats, err := getNetStats(snmppath)
+// parseSnmpDirect reads /proc/<pid>/net/snmp and writes wanted metrics
+// directly into res, avoiding intermediate map[string]map[string]string allocations.
+func parseSnmpDirect(path string, nsinum uint32, res map[string]map[string]map[uint32]uint64) error {
+	f, err := os.Open(path)
 	if err != nil {
-		return resMap, err
+		return err
 	}
+	defer f.Close()
 
-	for k, v := range snmpStats {
-		resMap[k] = v
-	}
-
-	return resMap, nil
-}
-
-func getNetStats(fileName string) (map[string]map[string]string, error) {
-	file, err := os.Open(fileName)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	return parseNetStats(file, fileName)
-}
-
-func parseNetStats(r io.Reader, fileName string) (map[string]map[string]string, error) {
-	var (
-		netStats = map[string]map[string]string{}
-		scanner  = bufio.NewScanner(r)
-	)
-
+	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
-		nameParts := strings.Split(scanner.Text(), " ")
-		scanner.Scan()
-		valueParts := strings.Split(scanner.Text(), " ")
-		// Remove trailing :.
-		protocol := strings.ToLower(nameParts[0][:len(nameParts[0])-1])
-		netStats[protocol] = map[string]string{}
-		if len(nameParts) != len(valueParts) {
-			return nil, fmt.Errorf("mismatch field count mismatch in %s: %s",
-				fileName, protocol)
+		headerLine := scanner.Text()
+		if !scanner.Scan() {
+			break
 		}
-		for i := 1; i < len(nameParts); i++ {
-			netStats[protocol][strings.ToLower(nameParts[i])] = valueParts[i]
+		valueLine := scanner.Text()
+
+		colonIdx := strings.IndexByte(headerLine, ':')
+		if colonIdx < 0 {
+			continue
+		}
+		protocol := strings.ToLower(headerLine[:colonIdx])
+
+		protoFields, ok := wantedSnmpFields[protocol]
+		if !ok {
+			continue
+		}
+
+		hi := colonIdx + 1
+		vi := strings.IndexByte(valueLine, ':')
+		if vi < 0 {
+			continue
+		}
+		vi++
+
+		hLen := len(headerLine)
+		vLen := len(valueLine)
+
+		for {
+			for hi < hLen && headerLine[hi] == ' ' {
+				hi++
+			}
+			if hi >= hLen {
+				break
+			}
+			hStart := hi
+			for hi < hLen && headerLine[hi] != ' ' {
+				hi++
+			}
+			fieldName := strings.ToLower(headerLine[hStart:hi])
+
+			for vi < vLen && valueLine[vi] == ' ' {
+				vi++
+			}
+			vStart := vi
+			for vi < vLen && valueLine[vi] != ' ' {
+				vi++
+			}
+
+			if wf, ok := protoFields[fieldName]; ok {
+				if vStart < vi {
+					val, err := strconv.ParseInt(valueLine[vStart:vi], 10, 64)
+					if err == nil {
+						res[wf.protoKey][wf.metricName][nsinum] = uint64(val)
+					}
+				}
+			}
 		}
 	}
 
-	return netStats, scanner.Err()
+	return scanner.Err()
 }

--- a/pkg/exporter/probe/proctcpsummary/proctcp.go
+++ b/pkg/exporter/probe/proctcpsummary/proctcp.go
@@ -3,13 +3,11 @@ package proctcpsummary
 import (
 	"bufio"
 	"context"
-	"encoding/hex"
 	"fmt"
-	"io"
-	"net"
 	"os"
 	"strconv"
-	"strings"
+	"sync"
+	"time"
 
 	"github.com/alibaba/kubeskoop/pkg/exporter/probe"
 	log "github.com/sirupsen/logrus"
@@ -43,36 +41,27 @@ const (
 	TCPTimewait    = 6
 	TCPCloseWait   = 8
 	TCPListen      = 10
-
-	readLimit = 4294967296 // Byte -> 4 GiB
 )
 
-type (
-	NetIPSocket []*netIPSocketLine
+type tcpSummary struct {
+	established uint64
+	timeWait    uint64
+	closeWait   uint64
+	synSent     uint64
+	synRecv     uint64
+	txQueue     uint64
+	rxQueue     uint64
+}
 
-	NetIPSocketSummary struct {
-		TxQueueLength uint64
-		RxQueueLength uint64
-		UsedSockets   uint64
-	}
-
-	netIPSocketLine struct {
-		Sl        uint64
-		LocalAddr net.IP
-		LocalPort uint64
-		RemAddr   net.IP
-		RemPort   uint64
-		St        uint64
-		TxQueue   uint64
-		RxQueue   uint64
-		UID       uint64
-		Inode     uint64
-	}
-
-	NetTCP []*netIPSocketLine
-
-	NetTCPSummary NetIPSocketSummary
-)
+func (s *tcpSummary) add(other *tcpSummary) {
+	s.established += other.established
+	s.timeWait += other.timeWait
+	s.closeWait += other.closeWait
+	s.synSent += other.synSent
+	s.synRecv += other.synRecv
+	s.txQueue += other.txQueue
+	s.rxQueue += other.rxQueue
+}
 
 var (
 	TCPSummaryMetrics = []probe.LegacyMetric{
@@ -86,7 +75,38 @@ var (
 	}
 
 	probeName = "tcpsummary"
+
+	collectCacheTTL = 2 * time.Second
 )
+
+// collectCache caches the result of collect() to avoid re-reading all
+// /proc/net/tcp files on every Prometheus scrape. The kernel generates
+// proc file content on each read by iterating the TCP hash table, so
+// reading 118 files per second is expensive. With a 2s TTL, rapid scrapes
+// (e.g. 1s interval) reuse cached results.
+type collectCache struct {
+	mu     sync.Mutex
+	result map[string]map[uint32]uint64
+	last   time.Time
+}
+
+var tcpCache = &collectCache{}
+
+func (c *collectCache) get() (map[string]map[uint32]uint64, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if time.Since(c.last) > collectCacheTTL {
+		ets := nettop.GetAllUniqueNetnsEntity()
+		if len(ets) == 0 {
+			log.Infof("failed collect tcp summary, no entity found")
+		}
+		c.result = collect(ets)
+		c.last = time.Now()
+	}
+
+	return c.result, nil
+}
 
 func init() {
 	probe.MustRegisterMetricsProbe(probeName, softNetProbeCreator)
@@ -112,11 +132,7 @@ func (s *ProcTCP) Stop(_ context.Context) error {
 }
 
 func (s *ProcTCP) CollectOnce() (map[string]map[uint32]uint64, error) {
-	ets := nettop.GetAllUniqueNetnsEntity()
-	if len(ets) == 0 {
-		log.Infof("failed collect tcp summary, no entity found")
-	}
-	return collect(ets), nil
+	return tcpCache.get()
 }
 
 func collect(pidlist []*nettop.Entity) map[string]map[uint32]uint64 {
@@ -127,190 +143,146 @@ func collect(pidlist []*nettop.Entity) map[string]map[uint32]uint64 {
 	}
 
 	for idx := range pidlist {
-		path := fmt.Sprintf("/proc/%d/net/tcp", pidlist[idx].GetPid())
-		summary, err := newNetTCP(path)
-		if err != nil {
-			log.Warnf("failed collect tcp, path %s, err: %v", path, err)
-			continue
-		}
-		summary6, err := newNetTCP(fmt.Sprintf("/proc/%d/net/tcp6", pidlist[idx].GetPid()))
-		if err != nil {
-			log.Warnf("failed collect tcp6, path %s, err: %v", path, err)
-			continue
-		}
-		est, tw, cw, ss, sr := summary.getEstTwCount()
-		est6, tw6, cw6, ss6, sr6 := summary6.getEstTwCount()
-		tx, rx := summary.getTxRxQueueLength()
-		tx6, rx6 := summary6.getTxRxQueueLength()
+		pid := pidlist[idx].GetPid()
 		nsinum := uint32(pidlist[idx].GetNetns())
-		resMap[TCPEstablishedConn][nsinum] = est + est6
-		resMap[TCPTimeWaitConn][nsinum] = tw + tw6
-		resMap[TCPCloseWaitConn][nsinum] = cw + cw6
-		resMap[TCPSynSentConn][nsinum] = ss + ss6
-		resMap[TCPSynRecvConn][nsinum] = sr + sr6
-		resMap[TCPTXQueue][nsinum] = tx + tx6
-		resMap[TCPRXQueue][nsinum] = rx + rx6
+
+		var combined tcpSummary
+		for _, proto := range []string{"tcp", "tcp6"} {
+			path := fmt.Sprintf("/proc/%d/net/%s", pid, proto)
+			s, err := collectTCPSummary(path)
+			if err != nil {
+				log.Warnf("failed collect %s, path %s, err: %v", proto, path, err)
+				continue
+			}
+			combined.add(&s)
+		}
+
+		resMap[TCPEstablishedConn][nsinum] = combined.established
+		resMap[TCPTimeWaitConn][nsinum] = combined.timeWait
+		resMap[TCPCloseWaitConn][nsinum] = combined.closeWait
+		resMap[TCPSynSentConn][nsinum] = combined.synSent
+		resMap[TCPSynRecvConn][nsinum] = combined.synRecv
+		resMap[TCPTXQueue][nsinum] = combined.txQueue
+		resMap[TCPRXQueue][nsinum] = combined.rxQueue
 	}
 
 	return resMap
 }
 
-func (n NetTCP) getEstTwCount() (est, tw, cw, ss, sr uint64) {
-	for idx := range n {
-		switch n[idx].St {
-		case TCPEstablished:
-			est++
-		case TCPTimewait:
-			tw++
-		case TCPCloseWait:
-			cw++
-		case TCPSynSent:
-			ss++
-		case TCPSynRecv:
-			sr++
-		}
-	}
-	return est, tw, cw, ss, sr
-}
-
-func (n NetTCP) getTxRxQueueLength() (tx uint64, rx uint64) {
-	for idx := range n {
-		if n[idx].St != TCPListen {
-			tx += n[idx].TxQueue
-			rx += n[idx].RxQueue
-		}
-	}
-	return tx, rx
-}
-
-// newNetTCP creates a new NetTCP{,6} from the contents of the given file.
-func newNetTCP(file string) (NetTCP, error) {
-	n, err := newNetIPSocket(file)
-	n1 := NetTCP(n)
-	return n1, err
-}
-
-func newNetIPSocket(file string) (NetIPSocket, error) {
+// collectTCPSummary reads a /proc/{pid}/net/tcp{,6} file and accumulates
+// state counts and queue lengths in a single pass. Only fields 3 (st) and
+// 4 (tx_queue:rx_queue) are parsed; IP addresses, ports, UID, and inode
+// are skipped entirely to avoid unnecessary allocations and CPU.
+func collectTCPSummary(file string) (tcpSummary, error) {
+	var s tcpSummary
 	f, err := os.Open(file)
 	if err != nil {
-		return nil, err
+		return s, err
 	}
 	defer f.Close()
 
-	var netIPSocket NetIPSocket
-
-	lr := io.LimitReader(f, readLimit)
-	s := bufio.NewScanner(lr)
-	s.Scan() // skip first line with headers
-	for s.Scan() {
-		fields := strings.Fields(s.Text())
-		line, err := parseNetIPSocketLine(fields)
+	scanner := bufio.NewScanner(f)
+	scanner.Scan() // skip header line
+	for scanner.Scan() {
+		line := scanner.Text()
+		st, txq, rxq, err := parseStAndQueues(line)
 		if err != nil {
-			return nil, err
+			continue // skip malformed lines
 		}
-		netIPSocket = append(netIPSocket, line)
+		switch st {
+		case TCPEstablished:
+			s.established++
+		case TCPTimewait:
+			s.timeWait++
+		case TCPCloseWait:
+			s.closeWait++
+		case TCPSynSent:
+			s.synSent++
+		case TCPSynRecv:
+			s.synRecv++
+		}
+		if st != TCPListen {
+			s.txQueue += txq
+			s.rxQueue += rxq
+		}
 	}
-	if err := s.Err(); err != nil {
-		return nil, err
-	}
-	return netIPSocket, nil
+	return s, scanner.Err()
 }
 
-// parseNetIPSocketLine parses a single line, represented by a list of fields.
-func parseNetIPSocketLine(fields []string) (*netIPSocketLine, error) {
-	line := &netIPSocketLine{}
-	if len(fields) < 10 {
-		return nil, fmt.Errorf(
-			"cannot parse net socket line as it has less then 10 columns %q",
-			strings.Join(fields, " "),
-		)
-	}
-	var err error // parse error
+// parseStAndQueues extracts the st (field 3) and tx_queue:rx_queue (field 4)
+// from a /proc/net/tcp line by index-based scanning, without allocating
+// intermediate slices or strings.
+//
+// /proc/net/tcp line format:
+//
+//	sl  local_address rem_address   st tx_queue:rx_queue ...
+//	0:  0100007F:1F90 00000000:0000 0A 00000000:00000000 00:00000000 ...
+//
+// Fields are separated by whitespace. We skip to field 3 (st) and field 4
+// (tx_queue:rx_queue) using manual index advancement.
+func parseStAndQueues(line string) (st, txq, rxq uint64, err error) {
+	n := len(line)
+	i := 0
 
-	// sl
-	s := strings.Split(fields[0], ":")
-	if len(s) != 2 {
-		return nil, fmt.Errorf("cannot parse sl field in socket line %q", fields[0])
-	}
-
-	if line.Sl, err = strconv.ParseUint(s[0], 0, 64); err != nil {
-		return nil, fmt.Errorf("cannot parse sl value in socket line: %w", err)
-	}
-	// local_address
-	l := strings.Split(fields[1], ":")
-	if len(l) != 2 {
-		return nil, fmt.Errorf("cannot parse local_address field in socket line %q", fields[1])
-	}
-	if line.LocalAddr, err = parseIP(l[0]); err != nil {
-		return nil, err
-	}
-	if line.LocalPort, err = strconv.ParseUint(l[1], 16, 64); err != nil {
-		return nil, fmt.Errorf("cannot parse local_address port value in socket line: %w", err)
+	// Skip 3 fields (sl, local_address, rem_address) to reach st (field 3)
+	for field := 0; field < 3; field++ {
+		// skip leading whitespace
+		for i < n && (line[i] == ' ' || line[i] == '\t') {
+			i++
+		}
+		// skip field content
+		for i < n && line[i] != ' ' && line[i] != '\t' {
+			i++
+		}
 	}
 
-	// remote_address
-	r := strings.Split(fields[2], ":")
-	if len(r) != 2 {
-		return nil, fmt.Errorf("cannot parse rem_address field in socket line %q", fields[1])
+	// skip whitespace before st field
+	for i < n && (line[i] == ' ' || line[i] == '\t') {
+		i++
 	}
-	if line.RemAddr, err = parseIP(r[0]); err != nil {
-		return nil, err
+	// extract st (hex)
+	start := i
+	for i < n && line[i] != ' ' && line[i] != '\t' {
+		i++
 	}
-	if line.RemPort, err = strconv.ParseUint(r[1], 16, 64); err != nil {
-		return nil, fmt.Errorf("cannot parse rem_address port value in socket line: %w", err)
+	if start == i {
+		return 0, 0, 0, fmt.Errorf("missing st field")
 	}
-
-	// st
-	if line.St, err = strconv.ParseUint(fields[3], 16, 64); err != nil {
-		return nil, fmt.Errorf("cannot parse st value in socket line: %w", err)
-	}
-
-	// tx_queue and rx_queue
-	q := strings.Split(fields[4], ":")
-	if len(q) != 2 {
-		return nil, fmt.Errorf(
-			"cannot parse tx/rx queues in socket line as it has a missing colon %q",
-			fields[4],
-		)
-	}
-	if line.TxQueue, err = strconv.ParseUint(q[0], 16, 64); err != nil {
-		return nil, fmt.Errorf("cannot parse tx_queue value in socket line: %w", err)
-	}
-	if line.RxQueue, err = strconv.ParseUint(q[1], 16, 64); err != nil {
-		return nil, fmt.Errorf("cannot parse rx_queue value in socket line: %w", err)
-	}
-
-	// uid
-	if line.UID, err = strconv.ParseUint(fields[7], 0, 64); err != nil {
-		return nil, fmt.Errorf("cannot parse uid value in socket line: %w", err)
-	}
-
-	// inode
-	if line.Inode, err = strconv.ParseUint(fields[9], 0, 64); err != nil {
-		return nil, fmt.Errorf("cannot parse inode value in socket line: %w", err)
-	}
-
-	return line, nil
-}
-
-func parseIP(hexIP string) (net.IP, error) {
-	var byteIP []byte
-	byteIP, err := hex.DecodeString(hexIP)
+	st, err = strconv.ParseUint(line[start:i], 16, 64)
 	if err != nil {
-		return nil, fmt.Errorf("cannot parse address field in socket line %q", hexIP)
+		return 0, 0, 0, err
 	}
-	switch len(byteIP) {
-	case 4:
-		return net.IP{byteIP[3], byteIP[2], byteIP[1], byteIP[0]}, nil
-	case 16:
-		i := net.IP{
-			byteIP[3], byteIP[2], byteIP[1], byteIP[0],
-			byteIP[7], byteIP[6], byteIP[5], byteIP[4],
-			byteIP[11], byteIP[10], byteIP[9], byteIP[8],
-			byteIP[15], byteIP[14], byteIP[13], byteIP[12],
-		}
-		return i, nil
-	default:
-		return nil, fmt.Errorf("unable to parse IP %s", hexIP)
+
+	// skip whitespace before tx_queue:rx_queue field
+	for i < n && (line[i] == ' ' || line[i] == '\t') {
+		i++
 	}
+	// extract tx_queue (hex, before ':')
+	start = i
+	for i < n && line[i] != ':' {
+		i++
+	}
+	if i >= n {
+		return 0, 0, 0, fmt.Errorf("missing queue field")
+	}
+	txq, err = strconv.ParseUint(line[start:i], 16, 64)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	// skip ':'
+	i++
+	// extract rx_queue (hex, until whitespace)
+	start = i
+	for i < n && line[i] != ' ' && line[i] != '\t' {
+		i++
+	}
+	if start == i {
+		return 0, 0, 0, fmt.Errorf("missing rx_queue field")
+	}
+	rxq, err = strconv.ParseUint(line[start:i], 16, 64)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	return st, txq, rxq, nil
 }

--- a/pkg/exporter/probe/proctcpsummary/proctcp.go
+++ b/pkg/exporter/probe/proctcpsummary/proctcp.go
@@ -101,7 +101,14 @@ func (c *collectCache) get() (map[string]map[uint32]uint64, error) {
 		if len(ets) == 0 {
 			log.Infof("failed collect tcp summary, no entity found")
 		}
-		c.result = collect(ets)
+
+		sockDiagOnce.Do(probeSockDiagSupport)
+		if useSockDiag {
+			c.result = collectSockDiag(ets)
+		} else {
+			log.Debugf("sock_diag unavailable (%v), using proc", useSockDiagErr)
+			c.result = collect(ets)
+		}
 		c.last = time.Now()
 	}
 

--- a/pkg/exporter/probe/proctcpsummary/proctcp_test.go
+++ b/pkg/exporter/probe/proctcpsummary/proctcp_test.go
@@ -153,7 +153,7 @@ func BenchmarkParseStAndQueues(b *testing.B) {
 	line := "   0: 0100007F:1F90 0100007F:CEA4 01 00000100:00000200 00:00000000 00000000  1000        0 54321 1 0000000000000000 100 0 0 10 0"
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		parseStAndQueues(line)
+		_, _, _, _ = parseStAndQueues(line)
 	}
 }
 
@@ -166,11 +166,13 @@ func BenchmarkCollectTCPSummary(b *testing.B) {
 	}
 	dir := b.TempDir()
 	path := filepath.Join(dir, "tcp")
-	os.WriteFile(path, lines, 0644)
+	if err := os.WriteFile(path, lines, 0644); err != nil {
+		b.Fatal(err)
+	}
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		collectTCPSummary(path)
+		_, _ = collectTCPSummary(path)
 	}
 }

--- a/pkg/exporter/probe/proctcpsummary/proctcp_test.go
+++ b/pkg/exporter/probe/proctcpsummary/proctcp_test.go
@@ -1,0 +1,176 @@
+package proctcpsummary
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseStAndQueues(t *testing.T) {
+	tests := []struct {
+		name    string
+		line    string
+		wantSt  uint64
+		wantTxq uint64
+		wantRxq uint64
+		wantErr bool
+	}{
+		{
+			name:    "established connection",
+			line:    "   0: 0100007F:1F90 00000000:0000 01 00000000:00000000 00:00000000 00000000     0        0 12345 1 0000000000000000 100 0 0 10 0",
+			wantSt:  1, // TCPEstablished
+			wantTxq: 0,
+			wantRxq: 0,
+		},
+		{
+			name:    "time_wait connection",
+			line:    "   1: 0100007F:1F90 0100007F:CEA4 06 00000000:00000000 03:000008BB 00000000     0        0 0 3 0000000000000000",
+			wantSt:  6, // TCPTimewait
+			wantTxq: 0,
+			wantRxq: 0,
+		},
+		{
+			name:    "connection with queues",
+			line:    "  10: 0100007F:1F90 0100007F:CEA4 01 00000100:00000200 00:00000000 00000000  1000        0 54321 1 0000000000000000 100 0 0 10 0",
+			wantSt:  1,
+			wantTxq: 0x100,
+			wantRxq: 0x200,
+		},
+		{
+			name:    "listen socket",
+			line:    "   5: 00000000:0050 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 99999 1 0000000000000000 100 0 0 10 0",
+			wantSt:  0x0A, // TCPListen
+			wantTxq: 0,
+			wantRxq: 0,
+		},
+		{
+			name:    "close_wait connection",
+			line:    "   3: AC1F0064:ABCD EF012345:0050 08 00000010:00000020 00:00000000 00000000   100        0 12345 1 0000000000000000 100 0 0 10 0",
+			wantSt:  8, // TCPCloseWait
+			wantTxq: 0x10,
+			wantRxq: 0x20,
+		},
+		{
+			name:    "syn_sent connection",
+			line:    "   2: AC1F0064:ABCD EF012345:0050 02 00000000:00000000 01:00000E10 00000003   100        0 12345 1 0000000000000000 100 0 0 10 0",
+			wantSt:  2, // TCPSynSent
+			wantTxq: 0,
+			wantRxq: 0,
+		},
+		{
+			name:    "tcp6 line",
+			line:    "   0: 00000000000000000000000001000000:0277 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 15890 1 0000000000000000 100 0 0 10 0",
+			wantSt:  0x0A, // TCPListen
+			wantTxq: 0,
+			wantRxq: 0,
+		},
+		{
+			name:    "too short line",
+			line:    "   0: ",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st, txq, rxq, err := parseStAndQueues(tt.line)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if st != tt.wantSt {
+				t.Errorf("st = %d, want %d", st, tt.wantSt)
+			}
+			if txq != tt.wantTxq {
+				t.Errorf("txq = %d, want %d", txq, tt.wantTxq)
+			}
+			if rxq != tt.wantRxq {
+				t.Errorf("rxq = %d, want %d", rxq, tt.wantRxq)
+			}
+		})
+	}
+}
+
+func TestCollectTCPSummary(t *testing.T) {
+	// Create a temp file simulating /proc/net/tcp
+	content := `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 0100007F:1F90 00000000:0000 01 00000000:00000000 00:00000000 00000000     0        0 12345 1 0000000000000000 100 0 0 10 0
+   1: 0100007F:1F91 0100007F:CEA4 01 00000010:00000020 00:00000000 00000000     0        0 12346 1 0000000000000000 100 0 0 10 0
+   2: 0100007F:1F92 0100007F:CEA5 06 00000000:00000000 03:000008BB 00000000     0        0 0 3 0000000000000000
+   3: 0100007F:1F93 0100007F:CEA6 08 00000005:00000003 00:00000000 00000000     0        0 12347 1 0000000000000000 100 0 0 10 0
+   4: 0100007F:1F94 0100007F:CEA7 02 00000000:00000000 01:00000E10 00000003     0        0 12348 1 0000000000000000 100 0 0 10 0
+   5: 00000000:0050 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 99999 1 0000000000000000 100 0 0 10 0
+   6: 0100007F:1F95 0100007F:CEA8 03 00000000:00000000 00:00000000 00000000     0        0 12349 1 0000000000000000 100 0 0 10 0
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tcp")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := collectTCPSummary(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// 2 established (lines 0,1)
+	if s.established != 2 {
+		t.Errorf("established = %d, want 2", s.established)
+	}
+	// 1 time_wait (line 2)
+	if s.timeWait != 1 {
+		t.Errorf("timeWait = %d, want 1", s.timeWait)
+	}
+	// 1 close_wait (line 3)
+	if s.closeWait != 1 {
+		t.Errorf("closeWait = %d, want 1", s.closeWait)
+	}
+	// 1 syn_sent (line 4)
+	if s.synSent != 1 {
+		t.Errorf("synSent = %d, want 1", s.synSent)
+	}
+	// 1 syn_recv (line 6)
+	if s.synRecv != 1 {
+		t.Errorf("synRecv = %d, want 1", s.synRecv)
+	}
+	// tx_queue: 0+0x10+0+0x05+0+0 = 0x15 = 21 (listen excluded)
+	if s.txQueue != 0x15 {
+		t.Errorf("txQueue = %d, want %d", s.txQueue, 0x15)
+	}
+	// rx_queue: 0+0x20+0+0x03+0+0 = 0x23 = 35 (listen excluded)
+	if s.rxQueue != 0x23 {
+		t.Errorf("rxQueue = %d, want %d", s.rxQueue, 0x23)
+	}
+}
+
+func BenchmarkParseStAndQueues(b *testing.B) {
+	line := "   0: 0100007F:1F90 0100007F:CEA4 01 00000100:00000200 00:00000000 00000000  1000        0 54321 1 0000000000000000 100 0 0 10 0"
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		parseStAndQueues(line)
+	}
+}
+
+func BenchmarkCollectTCPSummary(b *testing.B) {
+	// Create test file with realistic content
+	var lines []byte
+	lines = append(lines, []byte("  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n")...)
+	for i := 0; i < 50; i++ {
+		lines = append(lines, []byte("   0: 0100007F:1F90 0100007F:CEA4 01 00000000:00000000 00:00000000 00000000     0        0 12345 1 0000000000000000 100 0 0 10 0\n")...)
+	}
+	dir := b.TempDir()
+	path := filepath.Join(dir, "tcp")
+	os.WriteFile(path, lines, 0644)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		collectTCPSummary(path)
+	}
+}

--- a/pkg/exporter/probe/proctcpsummary/sockdiag.go
+++ b/pkg/exporter/probe/proctcpsummary/sockdiag.go
@@ -1,0 +1,185 @@
+package proctcpsummary
+
+import (
+	"fmt"
+	"sync"
+	"syscall"
+
+	"github.com/alibaba/kubeskoop/pkg/exporter/nettop"
+	"github.com/mdlayher/netlink"
+	"github.com/mdlayher/netlink/nlenc"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// NETLINK_SOCK_DIAG is the netlink protocol for socket diagnostics.
+	netlinkSockDiag = 4
+
+	// SOCK_DIAG_BY_FAMILY is the netlink message type for inet_diag_req_v2.
+	sockDiagByFamily = 20
+
+	// Size of inet_diag_req_v2 struct.
+	inetDiagReqV2Size = 56
+
+	// Minimum size of inet_diag_msg response struct.
+	inetDiagMsgSize = 72
+
+	// Offsets within inet_diag_msg.
+	offsetState  = 1  // idiag_state (uint8)
+	offsetRQueue = 56 // idiag_rqueue (uint32, native endian)
+	offsetWQueue = 60 // idiag_wqueue (uint32, native endian)
+
+	// allTCPStates is a bitmask for all TCP states (1-11).
+	allTCPStates = 0xFFF
+)
+
+var (
+	sockDiagOnce   sync.Once
+	useSockDiag    bool
+	useSockDiagErr error
+)
+
+// probeSockDiagSupport tests whether NETLINK_SOCK_DIAG is available by
+// attempting a minimal query in the current (host) namespace.
+func probeSockDiagSupport() {
+	conn, err := netlink.Dial(netlinkSockDiag, nil)
+	if err != nil {
+		useSockDiag = false
+		useSockDiagErr = err
+		return
+	}
+	defer conn.Close()
+
+	req := netlink.Message{
+		Header: netlink.Header{
+			Type:  sockDiagByFamily,
+			Flags: netlink.Request | netlink.Dump,
+		},
+		Data: buildInetDiagReq(syscall.AF_INET),
+	}
+	_, err = conn.Execute(req)
+	if err != nil {
+		useSockDiag = false
+		useSockDiagErr = err
+		return
+	}
+	useSockDiag = true
+}
+
+// collectSockDiag collects TCP summary metrics for all entities using
+// NETLINK_SOCK_DIAG. It has the same return type as collect() (proc-based).
+func collectSockDiag(entities []*nettop.Entity) map[string]map[uint32]uint64 {
+	resMap := make(map[string]map[uint32]uint64)
+	for idx := range TCPSummaryMetrics {
+		resMap[TCPSummaryMetrics[idx].Name] = map[uint32]uint64{}
+	}
+
+	for _, et := range entities {
+		nsinum := uint32(et.GetNetns())
+		combined, err := collectSockDiagForEntity(et)
+		if err != nil {
+			log.Warnf("failed collect sock_diag for netns %d: %v", nsinum, err)
+			continue
+		}
+
+		resMap[TCPEstablishedConn][nsinum] = combined.established
+		resMap[TCPTimeWaitConn][nsinum] = combined.timeWait
+		resMap[TCPCloseWaitConn][nsinum] = combined.closeWait
+		resMap[TCPSynSentConn][nsinum] = combined.synSent
+		resMap[TCPSynRecvConn][nsinum] = combined.synRecv
+		resMap[TCPTXQueue][nsinum] = combined.txQueue
+		resMap[TCPRXQueue][nsinum] = combined.rxQueue
+	}
+
+	return resMap
+}
+
+// collectSockDiagForEntity queries TCP socket state for a single network
+// namespace via NETLINK_SOCK_DIAG. It opens a netlink connection in the
+// entity's namespace, sends AF_INET and AF_INET6 dump requests, and
+// parses the binary responses.
+func collectSockDiagForEntity(entity *nettop.Entity) (tcpSummary, error) {
+	nsHandle, err := entity.OpenNsHandle()
+	if err != nil {
+		return tcpSummary{}, fmt.Errorf("open ns handle: %w", err)
+	}
+	defer nsHandle.Close()
+
+	conn, err := netlink.Dial(netlinkSockDiag, &netlink.Config{
+		NetNS: int(nsHandle),
+	})
+	if err != nil {
+		return tcpSummary{}, fmt.Errorf("dial sock_diag: %w", err)
+	}
+	defer conn.Close()
+
+	var combined tcpSummary
+	for _, family := range []uint8{syscall.AF_INET, syscall.AF_INET6} {
+		req := netlink.Message{
+			Header: netlink.Header{
+				Type:  sockDiagByFamily,
+				Flags: netlink.Request | netlink.Dump,
+			},
+			Data: buildInetDiagReq(family),
+		}
+		msgs, err := conn.Execute(req)
+		if err != nil {
+			return tcpSummary{}, fmt.Errorf("execute sock_diag family %d: %w", family, err)
+		}
+		partial := parseDiagMsgs(msgs)
+		combined.add(&partial)
+	}
+
+	return combined, nil
+}
+
+// buildInetDiagReq builds a 56-byte inet_diag_req_v2 payload.
+//
+// Layout:
+//
+//	[0]   sdiag_family   = family (AF_INET or AF_INET6)
+//	[1]   sdiag_protocol = IPPROTO_TCP (6)
+//	[2]   idiag_ext      = 0 (no extensions)
+//	[3]   pad            = 0
+//	[4:8] idiag_states   = allTCPStates (native endian)
+//	[8:56] inet_diag_sockid = zeroed (dump all sockets)
+func buildInetDiagReq(family uint8) []byte {
+	data := make([]byte, inetDiagReqV2Size)
+	data[0] = family
+	data[1] = syscall.IPPROTO_TCP
+	nlenc.PutUint32(data[4:8], allTCPStates)
+	return data
+}
+
+// parseDiagMsgs extracts TCP state counts and queue lengths from a slice
+// of inet_diag_msg responses. Only 3 fields are read per message:
+// idiag_state (offset 1), idiag_rqueue (offset 56), idiag_wqueue (offset 60).
+func parseDiagMsgs(msgs []netlink.Message) tcpSummary {
+	var s tcpSummary
+	for _, msg := range msgs {
+		if len(msg.Data) < inetDiagMsgSize {
+			continue
+		}
+		state := msg.Data[offsetState]
+		rqueue := nlenc.Uint32(msg.Data[offsetRQueue : offsetRQueue+4])
+		wqueue := nlenc.Uint32(msg.Data[offsetWQueue : offsetWQueue+4])
+
+		switch uint64(state) {
+		case TCPEstablished:
+			s.established++
+		case TCPTimewait:
+			s.timeWait++
+		case TCPCloseWait:
+			s.closeWait++
+		case TCPSynSent:
+			s.synSent++
+		case TCPSynRecv:
+			s.synRecv++
+		}
+		if uint64(state) != TCPListen {
+			s.txQueue += uint64(wqueue)
+			s.rxQueue += uint64(rqueue)
+		}
+	}
+	return s
+}

--- a/pkg/exporter/probe/proctcpsummary/sockdiag_test.go
+++ b/pkg/exporter/probe/proctcpsummary/sockdiag_test.go
@@ -1,0 +1,146 @@
+package proctcpsummary
+
+import (
+	"syscall"
+	"testing"
+
+	"github.com/mdlayher/netlink"
+	"github.com/mdlayher/netlink/nlenc"
+)
+
+func TestBuildInetDiagReq(t *testing.T) {
+	tests := []struct {
+		name       string
+		family     uint8
+		wantFamily uint8
+		wantProto  uint8
+		wantStates uint32
+	}{
+		{
+			name:       "AF_INET",
+			family:     syscall.AF_INET,
+			wantFamily: syscall.AF_INET,
+			wantProto:  syscall.IPPROTO_TCP,
+			wantStates: allTCPStates,
+		},
+		{
+			name:       "AF_INET6",
+			family:     syscall.AF_INET6,
+			wantFamily: syscall.AF_INET6,
+			wantProto:  syscall.IPPROTO_TCP,
+			wantStates: allTCPStates,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := buildInetDiagReq(tt.family)
+			if len(data) != inetDiagReqV2Size {
+				t.Fatalf("size = %d, want %d", len(data), inetDiagReqV2Size)
+			}
+			if data[0] != tt.wantFamily {
+				t.Errorf("family = %d, want %d", data[0], tt.wantFamily)
+			}
+			if data[1] != tt.wantProto {
+				t.Errorf("protocol = %d, want %d", data[1], tt.wantProto)
+			}
+			if data[2] != 0 {
+				t.Errorf("idiag_ext = %d, want 0", data[2])
+			}
+			gotStates := nlenc.Uint32(data[4:8])
+			if gotStates != tt.wantStates {
+				t.Errorf("states = 0x%x, want 0x%x", gotStates, tt.wantStates)
+			}
+		})
+	}
+}
+
+// buildTestDiagMsg creates a minimal 72-byte inet_diag_msg for testing.
+func buildTestDiagMsg(family, state uint8, rqueue, wqueue uint32) []byte {
+	data := make([]byte, inetDiagMsgSize)
+	data[0] = family
+	data[1] = state
+	nlenc.PutUint32(data[offsetRQueue:offsetRQueue+4], rqueue)
+	nlenc.PutUint32(data[offsetWQueue:offsetWQueue+4], wqueue)
+	return data
+}
+
+func TestParseDiagMsgs(t *testing.T) {
+	msgs := []netlink.Message{
+		// 2 ESTABLISHED connections with queues
+		{Data: buildTestDiagMsg(syscall.AF_INET, TCPEstablished, 100, 200)},
+		{Data: buildTestDiagMsg(syscall.AF_INET, TCPEstablished, 50, 30)},
+		// 1 TIME_WAIT
+		{Data: buildTestDiagMsg(syscall.AF_INET, TCPTimewait, 0, 0)},
+		// 1 CLOSE_WAIT with queues
+		{Data: buildTestDiagMsg(syscall.AF_INET, TCPCloseWait, 10, 20)},
+		// 1 SYN_SENT
+		{Data: buildTestDiagMsg(syscall.AF_INET, TCPSynSent, 0, 0)},
+		// 1 SYN_RECV
+		{Data: buildTestDiagMsg(syscall.AF_INET, TCPSynRecv, 0, 0)},
+		// 1 LISTEN (queues should be excluded)
+		{Data: buildTestDiagMsg(syscall.AF_INET, TCPListen, 0, 5)},
+		// 1 short message (should be skipped)
+		{Data: make([]byte, 10)},
+	}
+
+	s := parseDiagMsgs(msgs)
+
+	if s.established != 2 {
+		t.Errorf("established = %d, want 2", s.established)
+	}
+	if s.timeWait != 1 {
+		t.Errorf("timeWait = %d, want 1", s.timeWait)
+	}
+	if s.closeWait != 1 {
+		t.Errorf("closeWait = %d, want 1", s.closeWait)
+	}
+	if s.synSent != 1 {
+		t.Errorf("synSent = %d, want 1", s.synSent)
+	}
+	if s.synRecv != 1 {
+		t.Errorf("synRecv = %d, want 1", s.synRecv)
+	}
+	// rxQueue: 100 + 50 + 0 + 10 + 0 + 0 = 160 (LISTEN excluded)
+	if s.rxQueue != 160 {
+		t.Errorf("rxQueue = %d, want 160", s.rxQueue)
+	}
+	// txQueue: 200 + 30 + 0 + 20 + 0 + 0 = 250 (LISTEN excluded)
+	if s.txQueue != 250 {
+		t.Errorf("txQueue = %d, want 250", s.txQueue)
+	}
+}
+
+func TestParseDiagMsgsEmpty(t *testing.T) {
+	s := parseDiagMsgs(nil)
+	if s.established != 0 || s.timeWait != 0 || s.txQueue != 0 || s.rxQueue != 0 {
+		t.Errorf("expected zero summary for nil input, got %+v", s)
+	}
+}
+
+func BenchmarkParseDiagMsgs(b *testing.B) {
+	// Build 50 messages simulating a realistic namespace
+	msgs := make([]netlink.Message, 50)
+	for i := range msgs {
+		var state uint8
+		switch i % 5 {
+		case 0:
+			state = TCPEstablished
+		case 1:
+			state = TCPTimewait
+		case 2:
+			state = TCPCloseWait
+		case 3:
+			state = TCPListen
+		case 4:
+			state = TCPSynSent
+		}
+		msgs[i] = netlink.Message{Data: buildTestDiagMsg(syscall.AF_INET, state, uint32(i*10), uint32(i*5))}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		parseDiagMsgs(msgs)
+	}
+}

--- a/pkg/skoop/collector/podcollector/collector.go
+++ b/pkg/skoop/collector/podcollector/collector.go
@@ -536,8 +536,8 @@ func ruleCollector(sandboxInfo *netstack.NetNSInfo) error {
 			Priority: rule.Priority,
 			Family:   rule.Family,
 			Table:    rule.Table,
-			Mark:     rule.Mark,
-			Mask:     rule.Mask,
+			Mark:     int(rule.Mark),
+			Mask:     int(derefUint32(rule.Mask)),
 			Tos:      rule.Tos,
 			TunID:    rule.TunID,
 			Goto:     rule.Goto,
@@ -549,6 +549,13 @@ func ruleCollector(sandboxInfo *netstack.NetNSInfo) error {
 		})
 	}
 	return nil
+}
+
+func derefUint32(p *uint32) uint32 {
+	if p == nil {
+		return 0
+	}
+	return *p
 }
 
 func iptablesCollector(sandboxInfo *netstack.NetNSInfo) error {


### PR DESCRIPTION
## Summary

This MR addresses high CPU (~367m) and memory (~300Mi) consumption of kubeskoop-agent on nodes
with many pods (60+). Through a series of targeted optimizations, CPU is reduced by 72% to ~101m
and memory by 58% to ~126Mi.

## Changes

### 1. LinkManager abstraction (`linkmanager.go`)
- Centralized network interface management with netlink subscription for link events
- Replaced per-probe ad-hoc interface discovery in flow and nlqdisc probes
- Eliminated redundant netlink connections and polling

### 2. Switch from bswang/netlink fork to upstream vishvananda/netlink
- The forked netlink library had a busy-loop bug (nonblocking socket without epoll registration)
  causing unnecessary CPU consumption
- Migrated to the official upstream library

### 3. Optimize proctcpsummary /proc/net/tcp parsing (`proctcp.go`)
- Replaced regexp-based parsing with single-pass zero-allocation field extraction
- Added 2-second TTL cache to avoid redundant collection across metrics

### 4. NETLINK_SOCK_DIAG for TCP socket collection (`sockdiag.go`)
- Implemented binary SOCK_DIAG protocol (inet_diag) as replacement for text-based /proc/net/tcp
- 2.3x faster per-collection (713ms -> 306ms avg), 2.34x less kernel CPU
- Automatic fallback to /proc parsing if SOCK_DIAG is unavailable
- Benchmark at scale: up to 5x speedup at 10K+ sockets (p50)

### 5. Lazy-load kernel symbols (`kallsyms.go`)
- Changed unconditional init() loading of 214K symbols (~30MB) to sync.Once lazy loading
- Symbols only loaded when BPF probes (tracepacketloss, tracetcpretrans) are active
- Saves ~30MB heap for the common case where no BPF probes are enabled

### 6. Eliminate intermediate string map allocations (`procnetstat.go`, `procsnmp.go`)
- procnetstat: replaced map[string]map[string]string -> direct uint64 parsing, only extracting
  needed fields. Reduced cumulative allocations from ~7.7GB to near zero.
- procsnmp: same optimization for /proc/net/snmp (tcp/udp/ip protocols). Reduced ~550MB
  cumulative allocations.

## Performance Results (node with 63 pods, 59 unique namespaces)

| Metric               | Before  | After   | Reduction |
|----------------------|---------|---------|-----------|
| Pod CPU              | 367m    | 101m    | -72%      |
| Pod Memory (RSS)     | ~300Mi  | 126Mi   | -58%      |
| Go Heap (live)       | 52.7MB  | 32MB    | -39%      |
| GC cycles (2min)     | 1431    | 304     | -79%      |
| TCP collection (p50) | 687ms   | 210ms   | -70%      |
| Kernel CPU per coll. | 38.3s   | 16.4s   | -57%      |

## Test Plan

- [x] Unit tests for SOCK_DIAG parsing (sockdiag_test.go) and proc parsing (proctcp_test.go)
- [x] All 10 configured probes verified producing correct metrics post-deploy
  (conntrack, qdisc, netdev, io, sock, tcpsummary, tcp, tcpext, udp, rdma)
- [x] Metrics cross-validated between problem node (.51, 63 pods) and normal nodes
- [x] pprof heap/cpu profiling before and after each optimization
- [x] Standalone benchmark tool (cmd/tcpbench) validated SOCK_DIAG vs proc at
  0/1K/10K/50K socket scales
- [x] No new errors in inspector logs (rdma errors are pre-existing, unrelated)