### PR TITLE
memory optimization

### DIFF
--- a/deploy/helm/templates/configmap.yaml
+++ b/deploy/helm/templates/configmap.yaml
@@ -9,6 +9,7 @@ data:
     port: {{ .Values.agent.config.port }}
     enableController: {{ .Values.controller.enabled }}
     metrics:
+      disableCompression: {{ .Values.config.disableMetricsCompression }}
       additionalLabels:
       {{- toYaml .Values.config.additionalLabels | nindent 8 }}
       probes:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,4 +1,5 @@
 config:
+  disableMetricsCompression: true
 #  additionalLabels:
 #    - application=${labels:application}
 #      businessline=${labels:businessline}

--- a/deploy/net-exporter-config.yaml
+++ b/deploy/net-exporter-config.yaml
@@ -19,7 +19,7 @@ metrics:
       enablePortInLabel: false
   - name: tcpretrans
 event:
-  probes: 
+  probes:
   - name: biolatency
   - name: kernellatency
   - name: packetloss
@@ -27,6 +27,5 @@ event:
       enableStack: false
   - name: tcpreset
   - name: tcpretrans
-  sinks: 
+  sinks:
   - name: stderr
-

--- a/pkg/controller/ipcache/ipcache.go
+++ b/pkg/controller/ipcache/ipcache.go
@@ -22,8 +22,11 @@ import (
 )
 
 const (
-	MaxSyncBatchSize = 20
-	CompactThreshold = 10240
+	MaxSyncBatchSize      = 20
+	CompactThreshold      = 1024
+	MaxRetainedLogEntries = 10 * CompactThreshold
+	ClientBufferSize      = 1024
+	LogBufferSize         = 4 * 1024
 )
 
 type changeLog struct {
@@ -104,7 +107,7 @@ func (s *Service) WatchCache(request *rpc.WatchCacheRequest, server rpc.IPCacheS
 		revision: request.Revision,
 		closed:   false,
 		state:    stale,
-		ch:       make(chan *changeLog, 4*1024),
+		ch:       make(chan *changeLog, ClientBufferSize),
 	}
 
 	s.clients.PushBack(c)
@@ -116,9 +119,12 @@ loop:
 	for {
 		select {
 		case <-server.Context().Done():
-			c.closed = true
+			s.markClientClosed(c)
 			break loop
-		case cl := <-c.ch:
+		case cl, ok := <-c.ch:
+			if !ok {
+				return status.Error(codes.DataLoss, "watch client fell behind")
+			}
 			err := server.Send(&rpc.WatchCacheResponse{
 				Revision: cl.revision,
 				Opcode:   cl.opcode,
@@ -126,13 +132,19 @@ loop:
 			})
 			if err != nil {
 				log.Warningf("failed send watch response to client: %v", err)
-				c.closed = true
+				s.markClientClosed(c)
 				break loop
 			}
 		}
 	}
 
 	return nil
+}
+
+func (s *Service) markClientClosed(c *client) {
+	s.clientsLock.Lock()
+	c.closed = true
+	s.clientsLock.Unlock()
 }
 
 func findNext(slice []*changeLog, target uint64) int {
@@ -158,7 +170,7 @@ func NewService(podInformer coreinformers.PodInformer, nodeInformer coreinformer
 				entries: make(map[string]*rpc.CacheEntry),
 			},
 		},
-		logChan: make(chan *changeLog, 10*1024),
+		logChan: make(chan *changeLog, LogBufferSize),
 		clients: list.New(),
 		period:  uuid.NewString(),
 	}
@@ -391,25 +403,28 @@ func (s *Service) compactLog() {
 	s.storage.snapshot.lock.Lock()
 	defer s.storage.snapshot.lock.Unlock()
 
-	var minRevision uint64
+	minRevision := s.storage.revision.Load()
+	hasActiveClient := false
 
 	for e := s.clients.Front(); e != nil; e = e.Next() {
 		c := e.Value.(*client)
 		if c.closed {
 			continue
 		}
+		hasActiveClient = true
 		if c.revision < minRevision {
 			minRevision = c.revision
 		}
 	}
 
-	if minRevision == 0 {
+	if len(s.storage.log) == 0 || (!hasActiveClient && minRevision == s.storage.snapshot.revision) {
 		return
 	}
 
 	var first, last uint64
+	compactTo := 0
 
-	for i := 0; i < len(s.storage.log); {
+	for i := 0; i < len(s.storage.log); i++ {
 		cl := s.storage.log[i]
 		if cl.revision > minRevision {
 			break
@@ -420,34 +435,63 @@ func (s *Service) compactLog() {
 		last = cl.revision
 		apply(s.storage.snapshot.entries, cl)
 		s.storage.snapshot.revision = cl.revision
+		compactTo = i + 1
+	}
+
+	if compactTo > 0 {
+		copy(s.storage.log, s.storage.log[compactTo:])
+		for i := len(s.storage.log) - compactTo; i < len(s.storage.log); i++ {
+			s.storage.log[i] = nil
+		}
+		s.storage.log = s.storage.log[:len(s.storage.log)-compactTo]
 	}
 
 	if last > 0 {
-		log.Infof("compact log from %d(include) to %d(include)", first, last)
+		log.Infof("compact log from %d(include) to %d(include), remain %d", first, last, len(s.storage.log))
 	}
 }
 
 func (s *Service) copyClients(filter ...clientstate) []*client {
-	s.clientsLock.RLock()
-	defer s.clientsLock.RUnlock()
+	s.clientsLock.Lock()
+	defer s.clientsLock.Unlock()
 
 	var ret []*client
-	for e := s.clients.Front(); e != nil; e = e.Next() {
+	for e := s.clients.Front(); e != nil; {
+		next := e.Next()
 		c := e.Value.(*client)
 		if c.closed {
 			close(c.ch)
 			s.clients.Remove(e)
+			e = next
 			continue
 		}
 		if len(filter) == 0 || slices.Contains(filter, c.state) {
 			ret = append(ret, c)
 		}
+		e = next
 	}
 	return ret
 }
 
+func (s *Service) closeBackpressuredClients() int {
+	s.clientsLock.Lock()
+	defer s.clientsLock.Unlock()
+
+	closed := 0
+	for e := s.clients.Front(); e != nil; e = e.Next() {
+		c := e.Value.(*client)
+		if c.closed || c.state != blocking || len(c.ch) < cap(c.ch) {
+			continue
+		}
+		c.closed = true
+		closed++
+	}
+	return closed
+}
+
 func (s *Service) syncControl() {
 	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
 
 	var pendingLogs []*changeLog
 
@@ -459,7 +503,12 @@ func (s *Service) syncControl() {
 			//TODO check change log effectiveness, if change log has no effect on current data, ignore it to reduce sync
 
 			s.storage.log = append(s.storage.log, cl)
-			if len(s.storage.log) > CompactThreshold {
+			if len(s.storage.log) > MaxRetainedLogEntries {
+				if closed := s.closeBackpressuredClients(); closed > 0 {
+					log.Warnf("closed %d slow ipcache clients to compact retained logs", closed)
+				}
+				s.compactLog()
+			} else if len(s.storage.log) > CompactThreshold {
 				s.compactLog()
 			}
 
@@ -477,6 +526,7 @@ func (s *Service) syncControl() {
 			}
 
 			s.syncClients(maxSyncedRevision)
+			s.compactLog()
 		}
 	}
 }

--- a/pkg/exporter/cmd/config.go
+++ b/pkg/exporter/cmd/config.go
@@ -21,8 +21,9 @@ type InspServerConfig struct {
 }
 
 type MetricsConfig struct {
-	Probes           []ProbeConfig `yaml:"probes" mapstructure:"probes" json:"probes"`
-	AdditionalLabels []string      `yaml:"additionalLabels" mapstructure:"additionalLabels" json:"additionalLabels"`
+	Probes             []ProbeConfig `yaml:"probes" mapstructure:"probes" json:"probes"`
+	AdditionalLabels   []string      `yaml:"additionalLabels" mapstructure:"additionalLabels" json:"additionalLabels"`
+	DisableCompression bool          `yaml:"disableCompression" mapstructure:"disableCompression" json:"disableCompression"`
 }
 
 type EventConfig struct {
@@ -41,7 +42,11 @@ type ProbeConfig struct {
 }
 
 func loadConfig(path string) (*InspServerConfig, error) {
-	cfg := InspServerConfig{}
+	cfg := InspServerConfig{
+		MetricsConfig: MetricsConfig{
+			DisableCompression: true,
+		},
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed read config file %s: %w", path, err)

--- a/pkg/exporter/cmd/metricserver.go
+++ b/pkg/exporter/cmd/metricserver.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"net/http"
+	"sync/atomic"
 
 	"github.com/alibaba/kubeskoop/pkg/exporter/probe"
 	"github.com/alibaba/kubeskoop/pkg/exporter/util"
@@ -11,21 +12,20 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func newMetricsServer() (*MetricsServer, error) {
+func newMetricsServer(config MetricsConfig) (*MetricsServer, error) {
 
 	r := prometheus.NewRegistry()
-	handler := promhttp.HandlerFor(prometheus.Gatherers{
-		r,
-	}, promhttp.HandlerOpts{})
 
 	probeManager := &MetricsProbeManager{
 		prometheusRegistry: r,
 	}
 
-	return &MetricsServer{
+	server := &MetricsServer{
 		DynamicProbeServer: NewDynamicProbeServer[probe.MetricsProbe](probeManager),
-		httpHandler:        handler,
-	}, nil
+		prometheusRegistry: r,
+	}
+	server.SetDisableCompression(config.DisableCompression)
+	return server, nil
 }
 
 type MetricsProbeManager struct {
@@ -65,9 +65,17 @@ var _ ProbeManager[probe.MetricsProbe] = &MetricsProbeManager{}
 
 type MetricsServer struct {
 	*DynamicProbeServer[probe.MetricsProbe]
-	httpHandler http.Handler
+	prometheusRegistry *prometheus.Registry
+	httpHandler        atomic.Value
+}
+
+func (s *MetricsServer) SetDisableCompression(disable bool) {
+	handler := promhttp.HandlerFor(prometheus.Gatherers{
+		s.prometheusRegistry,
+	}, promhttp.HandlerOpts{DisableCompression: disable})
+	s.httpHandler.Store(handler)
 }
 
 func (s *MetricsServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	s.httpHandler.ServeHTTP(w, r)
+	s.httpHandler.Load().(http.Handler).ServeHTTP(w, r)
 }

--- a/pkg/exporter/cmd/server.go
+++ b/pkg/exporter/cmd/server.go
@@ -280,6 +280,7 @@ func (i *inspServer) reload() error {
 	}
 
 	ctx := context.TODO()
+	i.metricsServer.SetDisableCompression(cfg.MetricsConfig.DisableCompression)
 
 	err = i.metricsServer.Reload(ctx, cfg.MetricsConfig.Probes)
 	if err != nil {
@@ -375,7 +376,7 @@ func (i *inspServer) start(cfg *InspServerConfig) error {
 		return fmt.Errorf("failed init additional labels: %w", err)
 	}
 
-	i.metricsServer, err = newMetricsServer()
+	i.metricsServer, err = newMetricsServer(cfg.MetricsConfig)
 	if err != nil {
 		return fmt.Errorf("failed create metrics server: %w", err)
 	}

--- a/pkg/exporter/nettop/cgroup.go
+++ b/pkg/exporter/nettop/cgroup.go
@@ -2,10 +2,8 @@ package nettop
 
 import (
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -57,26 +55,18 @@ func tasksInsidePodCgroup(path string, absolutePath bool) []int {
 		tasksFileName = "cgroup.threads"
 	}
 
-	m := make(map[int]int)
-	err := filepath.Walk(base, func(path string, info fs.FileInfo, err error) error {
+	m := make(map[int]struct{})
+	err := filepath.WalkDir(base, func(path string, entry os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if !info.IsDir() && strings.HasSuffix(path, "/"+tasksFileName) {
+		if !entry.IsDir() && strings.HasSuffix(path, "/"+tasksFileName) {
 			tasks, err := os.ReadFile(path)
 			if err != nil {
 				return fmt.Errorf("failed read cgroup tasks %s: %w", path, err)
 			}
-			for _, s := range strings.Split(string(tasks), "\n") {
-				s = strings.TrimSpace(s)
-				if s == "" {
-					continue
-				}
-				i, err := strconv.Atoi(s)
-				if err != nil {
-					return fmt.Errorf("invalid tasks pid format in %s : %w", path, err)
-				}
-				m[i] = 1
+			if err := parseTaskPIDs(tasks, m); err != nil {
+				return fmt.Errorf("invalid tasks pid format in %s : %w", path, err)
 			}
 		}
 		return nil
@@ -86,9 +76,33 @@ func tasksInsidePodCgroup(path string, absolutePath bool) []int {
 		log.Errorf("failed list tasks: %v", err)
 	}
 
-	var ret []int
+	ret := make([]int, 0, len(m))
 	for k := range m {
 		ret = append(ret, k)
 	}
 	return ret
+}
+
+func parseTaskPIDs(data []byte, pids map[int]struct{}) error {
+	pid := 0
+	hasDigit := false
+	for _, b := range data {
+		switch {
+		case b >= '0' && b <= '9':
+			hasDigit = true
+			pid = pid*10 + int(b-'0')
+		case b == '\n' || b == '\r' || b == '\t' || b == ' ':
+			if hasDigit {
+				pids[pid] = struct{}{}
+				pid = 0
+				hasDigit = false
+			}
+		default:
+			return fmt.Errorf("unexpected byte %q", b)
+		}
+	}
+	if hasDigit {
+		pids[pid] = struct{}{}
+	}
+	return nil
 }

--- a/pkg/exporter/probe/legacy.go
+++ b/pkg/exporter/probe/legacy.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/alibaba/kubeskoop/pkg/exporter/bpfutil"
 	"github.com/alibaba/kubeskoop/pkg/exporter/nettop"
@@ -15,9 +16,32 @@ var StandardMetricsLabels = []string{"k8s_node", "k8s_namespace", "k8s_pod"}
 var TupleMetricsLabels = []string{"protocol", "src", "src_type", "src_node", "src_namespace", "src_pod", "dst", "dst_type", "dst_node", "dst_namespace", "dst_pod", "sport", "dport"}
 var AdditionalLabelValueExpr []string
 
+var standardLabelValuePool = sync.Pool{New: func() interface{} {
+	values := make([]string, 0, len(StandardMetricsLabels))
+	return &values
+}}
+
 func BuildStandardMetricsLabelValues(entity *nettop.Entity) []string {
-	metaPodLabels := []string{nettop.GetNodeName(), entity.GetPodNamespace(), entity.GetPodName()}
-	return append(metaPodLabels, BuildAdditionalLabelsValues(entity.GetLabels())...)
+	return appendStandardMetricsLabelValues(nil, entity)
+}
+
+func getStandardMetricsLabelValues(entity *nettop.Entity) *[]string {
+	values := standardLabelValuePool.Get().(*[]string)
+	*values = appendStandardMetricsLabelValues((*values)[:0], entity)
+	return values
+}
+
+func putStandardMetricsLabelValues(values *[]string) {
+	for i := range *values {
+		(*values)[i] = ""
+	}
+	*values = (*values)[:0]
+	standardLabelValuePool.Put(values)
+}
+
+func appendStandardMetricsLabelValues(dst []string, entity *nettop.Entity) []string {
+	dst = append(dst, nettop.GetNodeName(), entity.GetPodNamespace(), entity.GetPodName())
+	return appendAdditionalLabelsValues(dst, entity.GetLabels())
 }
 
 type LegacyMetric struct {
@@ -41,11 +65,17 @@ func InitAdditionalLabels(additionalLabels []string) error {
 }
 
 func BuildAdditionalLabelsValues(podLabels map[string]string) []string {
-	if len(AdditionalLabelValueExpr) == 0 {
+	values := appendAdditionalLabelsValues(nil, podLabels)
+	if values == nil {
 		return []string{}
 	}
+	return values
+}
 
-	var values []string
+func appendAdditionalLabelsValues(values []string, podLabels map[string]string) []string {
+	if len(AdditionalLabelValueExpr) == 0 {
+		return values
+	}
 
 	var replaceAllStringSubmatchFunc = func(re *regexp.Regexp, str string, repl func([]string) string) string {
 		result := ""
@@ -135,8 +165,9 @@ func (l *legacyBatchMetrics) Collect(metrics chan<- prometheus.Metric) {
 			if err != nil || et == nil {
 				continue
 			}
-			labelValues := BuildStandardMetricsLabelValues(et)
-			emit(newMetricsName(l.module, key), labelValues, float64(value))
+			labelValues := getStandardMetricsLabelValues(et)
+			emit(newMetricsName(l.module, key), *labelValues, float64(value))
+			putStandardMetricsLabelValues(labelValues)
 		}
 	}
 }

--- a/pkg/exporter/probe/nlqdisc/nlqdiscstats.go
+++ b/pkg/exporter/probe/nlqdisc/nlqdiscstats.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"sync"
 	"syscall"
+	"time"
 
 	"github.com/alibaba/kubeskoop/pkg/exporter/probe"
 
@@ -39,6 +41,8 @@ const (
 	// __TCAStats_MAX
 
 	familyRoute = 0
+
+	ifaceMapTTL = time.Minute
 )
 
 var (
@@ -59,6 +63,13 @@ var (
 		{Name: Backlog, Help: "The total amount of data currently in the queue (in bytes)."},
 		{Name: Overlimits, Help: "The total number of packets that exceeded the configured limits."},
 	}
+
+	qdiscReqPool = sync.Pool{New: func() interface{} {
+		return &netlink.Message{Data: make([]byte, 20)}
+	}}
+	linkReqPool = sync.Pool{New: func() interface{} {
+		return &netlink.Message{Data: make([]byte, 16)}
+	}}
 )
 
 func init() {
@@ -66,20 +77,45 @@ func init() {
 }
 
 func qdiscProbeCreator() (probe.MetricsProbe, error) {
-	p := &Probe{}
+	p := &Probe{
+		clients: make(map[int]*qdiscClient),
+	}
 
 	batchMetrics := probe.NewLegacyBatchMetrics(probeName, qdiscMetrics, p.CollectOnce)
 
 	return probe.NewMetricsProbe(probeName, p, batchMetrics), nil
 }
 
-type Probe struct{}
+type Probe struct {
+	lock    sync.Mutex
+	clients map[int]*qdiscClient
+	stopped bool
+}
+
+type qdiscClient struct {
+	lock          sync.Mutex
+	conn          *netlink.Conn
+	ifaceMap      map[int]string
+	ifaceMapUntil time.Time
+}
 
 func (p *Probe) Start(_ context.Context) error {
+	p.lock.Lock()
+	p.stopped = false
+	p.lock.Unlock()
 	return nil
 }
 
 func (p *Probe) Stop(_ context.Context) error {
+	p.lock.Lock()
+	p.stopped = true
+	clients := p.clients
+	p.clients = make(map[int]*qdiscClient)
+	p.lock.Unlock()
+	for netns, client := range clients {
+		client.close()
+		delete(clients, netns)
+	}
 	return nil
 }
 
@@ -90,8 +126,10 @@ func (p *Probe) CollectOnce() (map[string]map[uint32]uint64, error) {
 	}
 
 	ets := nettop.GetAllUniqueNetnsEntity()
+	activeNetns := make(map[int]struct{}, len(ets))
 	for _, et := range ets {
-		stats, err := getQdiscStats(et)
+		activeNetns[et.GetNetns()] = struct{}{}
+		stats, err := p.getQdiscStats(et)
 		if err != nil {
 			log.Errorf("%s failed get qdisc stats: %v", probeName, err)
 			continue
@@ -109,22 +147,27 @@ func (p *Probe) CollectOnce() (map[string]map[uint32]uint64, error) {
 			}
 		}
 	}
+	p.closeUnusedClients(activeNetns)
 
 	return resMap, nil
 }
 
-func getQdiscStats(entity *nettop.Entity) ([]QdiscInfo, error) {
+func (p *Probe) getQdiscStats(entity *nettop.Entity) ([]QdiscInfo, error) {
 	nsHandle, err := entity.OpenNsHandle()
 	if err != nil {
 		return nil, err
 	}
 	defer nsHandle.Close()
 
-	c, err := getConn(int(nsHandle))
+	client, err := p.getClient(entity.GetNetns(), int(nsHandle))
 	if err != nil {
 		return nil, err
 	}
-	defer c.Close()
+	client.lock.Lock()
+	if client.conn == nil {
+		client.lock.Unlock()
+		return nil, fmt.Errorf("netlink connection for netns %d is closed", entity.GetNetns())
+	}
 
 	// Build interface index -> name map for this namespace.
 	var ifaceMap map[int]string
@@ -135,25 +178,19 @@ func getQdiscStats(entity *nettop.Entity) ([]QdiscInfo, error) {
 			ifaceMap[l.Index] = l.Name
 		}
 	} else {
-		ifaceMap, err = getInterfaceMap(c)
-		if err != nil {
-			log.Warnf("%s failed get interface map for netns %d: %v", probeName, entity.GetNetns(), err)
-			ifaceMap = make(map[int]string)
-		}
+		ifaceMap = client.cachedInterfaceMap(entity.GetNetns())
 	}
 
-	req := netlink.Message{
-		Header: netlink.Header{
-			Flags: netlink.Request | netlink.Dump,
-			Type:  38, // RTM_GETQDISC
-		},
-		Data: make([]byte, 20),
-	}
+	req := qdiscRequest()
+	defer putQdiscRequest(req)
 
-	msgs, err := c.Execute(req)
+	msgs, err := client.conn.Execute(*req)
 	if err != nil {
+		client.lock.Unlock()
+		p.dropClient(entity.GetNetns(), client)
 		return nil, fmt.Errorf("failed to execute request: %v", err)
 	}
+	client.lock.Unlock()
 
 	res := []QdiscInfo{}
 	for _, msg := range msgs {
@@ -168,18 +205,128 @@ func getQdiscStats(entity *nettop.Entity) ([]QdiscInfo, error) {
 	return res, nil
 }
 
+func (p *Probe) getClient(netns, nsfd int) (*qdiscClient, error) {
+	p.lock.Lock()
+	if p.stopped {
+		p.lock.Unlock()
+		return nil, fmt.Errorf("%s probe is stopped", probeName)
+	}
+	client := p.clients[netns]
+	p.lock.Unlock()
+	if client != nil {
+		return client, nil
+	}
+
+	c, err := getConn(nsfd)
+	if err != nil {
+		return nil, err
+	}
+	client = &qdiscClient{conn: c}
+
+	p.lock.Lock()
+	if p.stopped {
+		p.lock.Unlock()
+		client.close()
+		return nil, fmt.Errorf("%s probe is stopped", probeName)
+	}
+	if existing := p.clients[netns]; existing != nil {
+		p.lock.Unlock()
+		client.close()
+		return existing, nil
+	}
+	p.clients[netns] = client
+	p.lock.Unlock()
+	return client, nil
+}
+
+func (p *Probe) dropClient(netns int, client *qdiscClient) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	if p.clients[netns] == client {
+		client.close()
+		delete(p.clients, netns)
+	}
+}
+
+func (p *Probe) closeUnusedClients(active map[int]struct{}) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	for netns, client := range p.clients {
+		if _, ok := active[netns]; ok {
+			continue
+		}
+		client.close()
+		delete(p.clients, netns)
+	}
+}
+
+func (c *qdiscClient) close() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.conn != nil {
+		_ = c.conn.Close()
+		c.conn = nil
+	}
+	c.ifaceMap = nil
+	c.ifaceMapUntil = time.Time{}
+}
+
+func (c *qdiscClient) cachedInterfaceMap(netns int) map[int]string {
+	now := time.Now()
+	if c.ifaceMap != nil && now.Before(c.ifaceMapUntil) {
+		return c.ifaceMap
+	}
+	ifaceMap, err := getInterfaceMap(c.conn)
+	if err != nil {
+		log.Warnf("%s failed get interface map for netns %d: %v", probeName, netns, err)
+		ifaceMap = make(map[int]string)
+	}
+	c.ifaceMap = ifaceMap
+	c.ifaceMapUntil = now.Add(ifaceMapTTL)
+	return ifaceMap
+}
+
+func qdiscRequest() *netlink.Message {
+	req := qdiscReqPool.Get().(*netlink.Message)
+	req.Header = netlink.Header{Flags: netlink.Request | netlink.Dump, Type: 38} // RTM_GETQDISC
+	if cap(req.Data) < 20 {
+		req.Data = make([]byte, 20)
+	} else {
+		req.Data = req.Data[:20]
+	}
+	clear(req.Data)
+	return req
+}
+
+func putQdiscRequest(req *netlink.Message) {
+	req.Header = netlink.Header{}
+	qdiscReqPool.Put(req)
+}
+
+func linkRequest() *netlink.Message {
+	req := linkReqPool.Get().(*netlink.Message)
+	req.Header = netlink.Header{Flags: netlink.Request | netlink.Dump, Type: 18} // RTM_GETLINK
+	if cap(req.Data) < 16 {
+		req.Data = make([]byte, 16)
+	} else {
+		req.Data = req.Data[:16]
+	}
+	clear(req.Data)
+	return req
+}
+
+func putLinkRequest(req *netlink.Message) {
+	req.Header = netlink.Header{}
+	linkReqPool.Put(req)
+}
+
 // getInterfaceMap queries RTM_GETLINK on an existing netlink connection
 // and returns a map of interface index to interface name.
 func getInterfaceMap(c *netlink.Conn) (map[int]string, error) {
-	req := netlink.Message{
-		Header: netlink.Header{
-			Flags: netlink.Request | netlink.Dump,
-			Type:  18, // RTM_GETLINK
-		},
-		Data: make([]byte, 16), // struct ifinfomsg
-	}
+	req := linkRequest()
+	defer putLinkRequest(req)
 
-	msgs, err := c.Execute(req)
+	msgs, err := c.Execute(*req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute RTM_GETLINK request: %v", err)
 	}

--- a/pkg/exporter/probe/procio/procio.go
+++ b/pkg/exporter/probe/procio/procio.go
@@ -1,10 +1,13 @@
 package procio
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"os"
+	"strconv"
+	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -22,7 +25,16 @@ const (
 	IOWriteBytes   = "writebytes"
 
 	probeName = "io" // nolint
+
+	maxProcIOBufferSize = 1024 * 512
 )
+
+var procIOBufferPool = sync.Pool{New: func() interface{} {
+	buf := make([]byte, 0, 512)
+	return &buf
+}}
+
+func noopPutBuffer() {}
 
 func init() {
 	probe.MustRegisterMetricsProbe(probeName, ioProbeCreator)
@@ -99,30 +111,97 @@ func collectProcessIO(entity *nettop.Entity, emit probe.Emit) {
 func getProcessIOStat(pid int) (procfs.ProcIO, error) {
 	pio := procfs.ProcIO{}
 
-	data, err := readFileNoStat(fmt.Sprintf("/proc/%d/io", pid))
+	data, putBuffer, err := readFileNoStat(fmt.Sprintf("/proc/%d/io", pid))
 	if err != nil {
 		return pio, err
 	}
+	defer putBuffer()
 
-	ioFormat := "rchar: %d\nwchar: %d\nsyscr: %d\nsyscw: %d\n" +
-		"read_bytes: %d\nwrite_bytes: %d\n" +
-		"cancelled_write_bytes: %d\n"
-
-	_, err = fmt.Sscanf(string(data), ioFormat, &pio.RChar, &pio.WChar, &pio.SyscR,
-		&pio.SyscW, &pio.ReadBytes, &pio.WriteBytes, &pio.CancelledWriteBytes)
-
-	return pio, err
+	return pio, parseProcIOStat(data, &pio)
 }
 
-func readFileNoStat(filename string) ([]byte, error) {
-	const maxBufferSize = 1024 * 512
+func parseProcIOStat(data []byte, pio *procfs.ProcIO) error {
+	for len(data) > 0 {
+		line := data
+		if i := bytes.IndexByte(data, '\n'); i >= 0 {
+			line = data[:i]
+			data = data[i+1:]
+		} else {
+			data = nil
+		}
+		if len(line) == 0 {
+			continue
+		}
 
+		key, rawValue, ok := bytes.Cut(line, []byte(":"))
+		if !ok {
+			return fmt.Errorf("invalid proc io line %q", line)
+		}
+		value, err := strconv.ParseInt(string(bytes.TrimSpace(rawValue)), 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid proc io value %q: %w", rawValue, err)
+		}
+
+		switch string(key) {
+		case "rchar":
+			pio.RChar = uint64(value)
+		case "wchar":
+			pio.WChar = uint64(value)
+		case "syscr":
+			pio.SyscR = uint64(value)
+		case "syscw":
+			pio.SyscW = uint64(value)
+		case "read_bytes":
+			pio.ReadBytes = uint64(value)
+		case "write_bytes":
+			pio.WriteBytes = uint64(value)
+		case "cancelled_write_bytes":
+			pio.CancelledWriteBytes = value
+		}
+	}
+	return nil
+}
+
+func readFileNoStat(filename string) ([]byte, func(), error) {
 	f, err := os.Open(filename)
 	if err != nil {
-		return nil, err
+		return nil, noopPutBuffer, err
 	}
 	defer f.Close()
 
-	reader := io.LimitReader(f, maxBufferSize)
-	return io.ReadAll(reader)
+	bufp := procIOBufferPool.Get().(*[]byte)
+	buf := (*bufp)[:0]
+	reader := io.LimitReader(f, maxProcIOBufferSize)
+	for {
+		if len(buf) == cap(buf) {
+			if cap(buf) >= maxProcIOBufferSize {
+				break
+			}
+			newCap := cap(buf) * 2
+			if newCap == 0 {
+				newCap = 512
+			}
+			if newCap > maxProcIOBufferSize {
+				newCap = maxProcIOBufferSize
+			}
+			next := make([]byte, len(buf), newCap)
+			copy(next, buf)
+			buf = next
+		}
+		n, err := reader.Read(buf[len(buf):cap(buf)])
+		buf = buf[:len(buf)+n]
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			*bufp = buf[:0]
+			procIOBufferPool.Put(bufp)
+			return nil, nil, err
+		}
+	}
+
+	return buf, func() {
+		*bufp = buf[:0]
+		procIOBufferPool.Put(bufp)
+	}, nil
 }


### PR DESCRIPTION
### Memory optimization

  - Added a new `metrics.disableCompression` configuration option.
  - Updated the metrics HTTP handler to support toggling Prometheus response compression at startup and during config reload.

  ### IPCache memory control

  - Reduced IPCache compaction threshold from `10240` to `1024`.
  - Added bounded retained-log and client-buffer limits to reduce memory growth under slow or disconnected watch clients.
  - Improved IPCache client cleanup by closing stale clients and clearing compacted log references for better GC behavior.
  - Added protection against slow/backpressured watch clients blocking log compaction indefinitely.

  ### Exporter allocation reduction

  - Optimized cgroup task parsing by replacing string splitting/conversion with byte-level PID parsing.
  - Reused standard metric label value slices through a pool to reduce per-metric allocations.
  - Optimized `/proc/<pid>/io` collection by using pooled buffers and byte-level parsing instead of `fmt.Sscanf` over converted strings.

  ### Qdisc probe optimization

  - Reused netlink connections per network namespace instead of opening a new connection on every collection.
  - Added a short-lived interface map cache for qdisc collection.
  - Reused netlink request buffers through pools.
  - Added cleanup for inactive or failed qdisc netlink clients.