### PR TITLE
fix: add missing return after error in HTTP handlers

### DIFF
--- a/pkg/controller/cmd/server.go
+++ b/pkg/controller/cmd/server.go
@@ -163,6 +163,7 @@ func (s *Server) ListCaptureTasks(ctx *gin.Context) {
 	tasks, err := s.controller.CaptureList(ctx)
 	if err != nil {
 		ctx.AsciiJSON(http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("error list capture task: %v", err)})
+		return
 	}
 	ctx.AsciiJSON(http.StatusOK, tasks)
 }
@@ -241,6 +242,7 @@ func (s *Server) GetFlowGraph(ctx *gin.Context) {
 		ti, err := strconv.Atoi(t)
 		if err != nil {
 			ctx.AsciiJSON(http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("cannot convert timestamp: %v", err)})
+			return
 		}
 		ts = time.Unix(int64(ti), 0)
 	} else {
@@ -250,6 +252,7 @@ func (s *Server) GetFlowGraph(ctx *gin.Context) {
 		ti, err := strconv.Atoi(f)
 		if err != nil {
 			ctx.AsciiJSON(http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("cannot convert timestamp: %v", err)})
+			return
 		}
 		fs = time.Unix(int64(ti), 0)
 	} else {


### PR DESCRIPTION
## Summary

- Add missing `return` after error responses in `ListCaptureTasks` and `GetFlowGraph`
- Prevents gin from writing two responses to the same request
- No changes to other files

## What changed

**server.go**:
- `ListCaptureTasks` (line 165): added `return` after error JSON response
- `GetFlowGraph` (lines 243, 252): added `return` after timestamp parse error responses

## What did NOT change

- No logic changes, only control flow correction
- All other handlers already have correct `return` statements

## Test plan

- [x] `go build ./pkg/controller/...` passes
- [ ] E2E: not verified (requires running cluster)

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)