### PR TITLE
fix: command injection in capture filter and ping destination

### DIFF
--- a/pkg/exporter/task-agent/capture.go
+++ b/pkg/exporter/task-agent/capture.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 	"syscall"
 	"time"
@@ -16,18 +17,43 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const (
-	//fixme: increase capture size by grpc
-	dumpCommand = "%v tcpdump -i any -C 100 -w %v %v" // size limit 100M
-)
+var validFilterRegex = regexp.MustCompile(`^[a-zA-Z0-9 ._:/\(\)\[\]!=<>&|,+*^%\-]+$`)
 
 type capture struct {
-	captureCommand string
-	captureFile    string
-	timeout        time.Duration
+	args        []string
+	captureFile string
+	timeout     time.Duration
+}
+
+func validateCaptureFilter(filter string) error {
+	if filter == "" {
+		return nil
+	}
+	if !validFilterRegex.MatchString(filter) {
+		return fmt.Errorf("invalid capture filter %q: contains disallowed characters", filter)
+	}
+	for _, token := range strings.Fields(filter) {
+		if strings.HasPrefix(token, "-") {
+			return fmt.Errorf("invalid capture filter: token %q looks like a flag, not a BPF expression", token)
+		}
+	}
+	return nil
+}
+
+func buildTcpdumpArgs(file, filter string) []string {
+	args := []string{"-i", "any", "-C", "100", "-w", file}
+	if filter != "" {
+		args = append(args, "--")
+		args = append(args, strings.Fields(filter)...)
+	}
+	return args
 }
 
 func (a *Agent) generateCaptures(id string, task *rpc.CaptureInfo) ([]capture, error) {
+	if err := validateCaptureFilter(task.GetFilter()); err != nil {
+		return nil, err
+	}
+
 	if task.Pod != nil && !task.Pod.HostNetwork {
 		var podEntry *nettop.Entity
 		entries := nettop.GetAllUniqueNetnsEntity()
@@ -40,25 +66,27 @@ func (a *Agent) generateCaptures(id string, task *rpc.CaptureInfo) ([]capture, e
 			return nil, fmt.Errorf("pod not found on nettop cache")
 		}
 		file := fmt.Sprintf("/tmp/%s_%s_%s_pod.pcap", id, task.Pod.Namespace, task.Pod.Name)
-		files := []capture{
+		tcpdumpArgs := buildTcpdumpArgs(file, task.GetFilter())
+		nsenterArgs := []string{"-t", fmt.Sprintf("%d", podEntry.GetPid()), "-n", "--", "tcpdump"}
+		nsenterArgs = append(nsenterArgs, tcpdumpArgs...)
+		return []capture{
 			{
-				captureCommand: fmt.Sprintf(dumpCommand, fmt.Sprintf("nsenter -t %v -n --", podEntry.GetPid()), file, task.GetFilter()),
-				captureFile:    file,
-				timeout:        time.Duration(task.CaptureDurationSeconds) * time.Second,
+				args:        append([]string{"nsenter"}, nsenterArgs...),
+				captureFile: file,
+				timeout:     time.Duration(task.CaptureDurationSeconds) * time.Second,
 			},
-		}
-		return files, nil
+		}, nil
 	}
 
 	file := fmt.Sprintf("/tmp/%s_%s_host.pcap", id, task.Node.Name)
+	tcpdumpArgs := buildTcpdumpArgs(file, task.GetFilter())
 	return []capture{
 		{
-			captureCommand: fmt.Sprintf(dumpCommand, "", file, task.GetFilter()),
-			captureFile:    file,
-			timeout:        time.Duration(task.CaptureDurationSeconds) * time.Second,
+			args:        append([]string{"tcpdump"}, tcpdumpArgs...),
+			captureFile: file,
+			timeout:     time.Duration(task.CaptureDurationSeconds) * time.Second,
 		},
 	}, nil
-
 }
 
 func (a *Agent) execute(captures []capture) (string, []byte, error) {
@@ -70,7 +98,7 @@ func (a *Agent) execute(captures []capture) (string, []byte, error) {
 			var (
 				output []byte
 				err    error
-				cmd    = exec.Command("sh", "-c", task.captureCommand)
+				cmd    = exec.Command(task.args[0], task.args[1:]...)
 			)
 			go func() {
 				output, err = cmd.CombinedOutput()
@@ -98,10 +126,12 @@ func (a *Agent) execute(captures []capture) (string, []byte, error) {
 	}()
 
 	fileType := "pcap"
-	outputCmd := exec.Command("sh", "-c", fmt.Sprintf("cat %v", captures[0].captureFile))
+	var outputCmd *exec.Cmd
 	if len(captures) > 1 {
 		fileType = "tar.gz"
 		outputCmd = exec.Command("tar", append([]string{"-czf", "-"}, lo.Map(captures, func(c capture, _ int) string { return c.captureFile })...)...)
+	} else {
+		outputCmd = exec.Command("cat", captures[0].captureFile)
 	}
 	output, err := outputCmd.Output()
 	if err != nil {

--- a/pkg/exporter/task-agent/capture_test.go
+++ b/pkg/exporter/task-agent/capture_test.go
@@ -1,0 +1,61 @@
+package taskagent
+
+import "testing"
+
+func TestValidateCaptureFilter(t *testing.T) {
+	tests := []struct {
+		name    string
+		filter  string
+		wantErr bool
+	}{
+		{"empty filter", "", false},
+		{"simple host filter", "host 10.0.0.1", false},
+		{"port filter", "port 80", false},
+		{"complex filter", "tcp port 80 and host 10.0.0.1", false},
+		{"filter with parens", "(tcp or udp) and port 80", false},
+		{"filter with comparison", "len > 100", false},
+		{"bpf arithmetic", "ip[0:1] & 0xf * 4 + 8", false},
+		{"bpf cidr", "net 10.0.0.0/24", false},
+		{"bpf portrange", "portrange 80-443", false},
+		{"bpf tcp flags", "tcp[tcpflags] & tcp-syn != 0", false},
+		{"injection semicolon", "; rm -rf /", true},
+		{"injection backtick", "`id`", true},
+		{"injection dollar", "$(whoami)", true},
+		{"injection newline", "host 10.0.0.1\nid", true},
+		{"injection pipe to shell", "x | sh", false},
+		{"flag injection -z", "-z /bin/sh", true},
+		{"flag injection -r", "-r /etc/shadow", true},
+		{"flag injection -w", "-w /tmp/evil", true},
+		{"flag injection -G", "-G 1", true},
+		{"flag injection mixed", "-z /tmp/x -G 1 port 80", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCaptureFilter(tt.filter)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateCaptureFilter(%q) error = %v, wantErr %v", tt.filter, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestBuildTcpdumpArgs(t *testing.T) {
+	args := buildTcpdumpArgs("/tmp/test.pcap", "tcp port 80")
+	expected := []string{"-i", "any", "-C", "100", "-w", "/tmp/test.pcap", "--", "tcp", "port", "80"}
+	if len(args) != len(expected) {
+		t.Fatalf("got %d args, want %d: %v", len(args), len(expected), args)
+	}
+	for i, a := range args {
+		if a != expected[i] {
+			t.Errorf("arg[%d] = %q, want %q", i, a, expected[i])
+		}
+	}
+}
+
+func TestBuildTcpdumpArgsEmpty(t *testing.T) {
+	args := buildTcpdumpArgs("/tmp/test.pcap", "")
+	expected := []string{"-i", "any", "-C", "100", "-w", "/tmp/test.pcap"}
+	if len(args) != len(expected) {
+		t.Fatalf("got %d args, want %d: %v", len(args), len(expected), args)
+	}
+}

--- a/pkg/exporter/task-agent/ping.go
+++ b/pkg/exporter/task-agent/ping.go
@@ -3,6 +3,7 @@ package taskagent
 import (
 	"context"
 	"fmt"
+	"net"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -38,7 +39,13 @@ func getLatency(pingResult string) (float64, float64, float64, error) {
 }
 
 func (a *Agent) ping(task *rpc.PingInfo) (string, error) {
-	var pingCmd string
+	destination := task.GetDestination()
+	if net.ParseIP(destination) == nil {
+		return "", fmt.Errorf("invalid ping destination: %q is not a valid IP address", destination)
+	}
+
+	var cmd *exec.Cmd
+	pingArgs := []string{"-A", "-c", "100", "-q", "-n", destination}
 	if task.Pod != nil && !task.Pod.HostNetwork {
 		var podEntry *nettop.Entity
 		entries := nettop.GetAllUniqueNetnsEntity()
@@ -50,12 +57,13 @@ func (a *Agent) ping(task *rpc.PingInfo) (string, error) {
 		if podEntry == nil {
 			return "", fmt.Errorf("pod not found on nettop cache")
 		}
-		pingCmd = fmt.Sprintf("nsenter -t %v -n -- ping -A -c 100 -q -n %v", podEntry.GetPid(), task.GetDestination())
+		nsenterArgs := []string{"-t", fmt.Sprintf("%d", podEntry.GetPid()), "-n", "--", "ping"}
+		nsenterArgs = append(nsenterArgs, pingArgs...)
+		cmd = exec.Command("nsenter", nsenterArgs...)
 	} else {
-		pingCmd = fmt.Sprintf("ping -A -c 100 -q -n %v", task.GetDestination())
+		cmd = exec.Command("ping", pingArgs...)
 	}
-	log.Infof("running command: %v", pingCmd)
-	cmd := exec.Command("sh", "-c", pingCmd)
+	log.Infof("running command: %v", cmd.Args)
 	output, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("error running command: %v, output: %v", err, string(output))

--- a/pkg/exporter/task-agent/ping_validate_test.go
+++ b/pkg/exporter/task-agent/ping_validate_test.go
@@ -1,0 +1,32 @@
+package taskagent
+
+import (
+	"net"
+	"testing"
+)
+
+func TestPingDestinationValidation(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		valid bool
+	}{
+		{"valid ipv4", "10.0.0.1", true},
+		{"valid ipv6", "::1", true},
+		{"valid ipv4 full", "192.168.1.100", true},
+		{"injection semicolon", "; rm -rf /", false},
+		{"injection backtick", "`id`", false},
+		{"injection dollar", "$(whoami)", false},
+		{"hostname", "example.com", false},
+		{"empty", "", false},
+		{"spaces", "10.0.0.1 ; id", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := net.ParseIP(tt.input) != nil
+			if result != tt.valid {
+				t.Errorf("net.ParseIP(%q) valid = %v, want %v", tt.input, result, tt.valid)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Fix critical command injection in `pkg/exporter/task-agent/capture.go` and `ping.go`
- Replace `exec.Command("sh", "-c", ...)` with direct argument passing
- Add input validation: regex allowlist + token-level dash-prefix rejection + `--` separator
- Add `net.ParseIP` validation for ping destination
- 23 unit tests added

## What changed

**capture.go**: Removed `sh -c` + `fmt.Sprintf`. Added `validateCaptureFilter()` (regex + dash-prefix check), `buildTcpdumpArgs()` (inserts `--` before filter). Changed struct from `captureCommand string` to `args []string`.

**ping.go**: Added `net.ParseIP()` validation. Replaced `sh -c` with direct `exec.Command`.

## What did NOT change

- Public API signatures unchanged
- gRPC protocol unchanged
- Timeout/SIGTERM logic preserved

## Test plan

- [x] 23 unit tests pass (filter validation, flag injection, IP validation)
- [x] Full `go build ./...` passes
- [x] 2 rounds adversarial workflow review, all blockers resolved
- [ ] E2E: not verified

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)