### PR TITLE
feat: add liveness and readiness probes to all components

### DIFF
--- a/deploy/helm/templates/controller/deployment.yaml
+++ b/deploy/helm/templates/controller/deployment.yaml
@@ -22,6 +22,18 @@ spec:
           imagePullPolicy: {{ .image.imagePullPolicy }}
           command:
             - "/bin/controller"
+          livenessProbe:
+            httpGet:
+              path: /nodes
+              port: 10264
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /nodes
+              port: 10264
+            initialDelaySeconds: 5
+            periodSeconds: 10
           volumeMounts:
             - name: lib
               mountPath: /var/lib/kubeskoop

--- a/deploy/helm/templates/daemonset.yaml
+++ b/deploy/helm/templates/daemonset.yaml
@@ -78,6 +78,18 @@ spec:
           - /bin/inspector
           - server
           - -d
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: {{ .config.port }}
+          initialDelaySeconds: 30
+          periodSeconds: 60
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: {{ .config.port }}
+          initialDelaySeconds: 10
+          periodSeconds: 30
         securityContext:
           capabilities:
             add:

--- a/deploy/helm/templates/webconsole/deployment.yaml
+++ b/deploy/helm/templates/webconsole/deployment.yaml
@@ -36,6 +36,18 @@ spec:
               value: "{{ .auth.username }}"
             - name: AUTH_PASSWORD
               value: "{{ .auth.password }}"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
           resources:
             {{- toYaml .resources | nindent 12 }}
           ports:


### PR DESCRIPTION
## Summary

- Add HTTP liveness/readiness probes to controller (`/nodes:10264`), webconsole (`/:8080`), agent (`/metrics`)
- No code changes, only Helm template modifications

## Test plan

- [x] Helm template renders correctly

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)